### PR TITLE
Potential fix for code scanning alert no. 31: Server-side URL redirect

### DIFF
--- a/ServerProgram/src/routing/send-301-redirect.ts
+++ b/ServerProgram/src/routing/send-301-redirect.ts
@@ -1,6 +1,18 @@
 import { Response } from "express";
 import { _throw  } from "../stdlib";
 
+const isLocalUrl = (url: string) => {
+  try {
+    return new URL(url, "https://example.com").origin === "https://example.com";
+  } catch (e) {
+    return false;
+  }
+};
+
 export const send301Redirect = (res: Response, pathname: string) => {
-  res.redirect(301, pathname);
+  if (isLocalUrl(pathname)) {
+    res.redirect(301, pathname);
+  } else {
+    res.redirect(301, "/");
+  }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/31](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/31)

To fix the problem, we need to validate the `pathname` parameter before using it in the `res.redirect` call. One way to do this is to ensure that the URL is local to the application and does not redirect to an external site. We can achieve this by implementing a function that checks if the URL is local and using this function to validate the `pathname` before performing the redirect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
