### PR TITLE
Potential fix for code scanning alert no. 30: Client-side cross-site scripting

### DIFF
--- a/html/analyze/package.json
+++ b/html/analyze/package.json
@@ -28,6 +28,7 @@
     "@music-analyzer/tonal-objects": "1.0.0",
     "@music-analyzer/view": "1.0.0",
     "@music-analyzer/view-parameters": "1.0.0",
-    "fast-xml-parser": "4.4.1"
+    "fast-xml-parser": "4.4.1",
+    "dompurify": "^3.2.4"
   }
 }

--- a/html/analyze/src/UIManager.ts
+++ b/html/analyze/src/UIManager.ts
@@ -1,4 +1,5 @@
 import { song_list } from "@music-analyzer/gttm";
+import DOMPurify from 'dompurify';
 
 export const updateTitle = (
   title: HTMLHeadingElement,
@@ -10,6 +11,7 @@ export const updateTitle = (
   const tune_no = tune_match ? Number(tune_match[1]) : Number(tune_id);
   if (tune_no) {
     const song_data = song_list[tune_no];
-    title.innerHTML = `[${mode || "???"}] ${tune_id}, ${song_data.author}, <i>"${song_data.title}"</i>`;
+    const sanitizedHTML = DOMPurify.sanitize(`[${mode || "???"}] ${tune_id}, ${song_data.author}, <i>"${song_data.title}"</i>`);
+    title.innerHTML = sanitizedHTML;
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/30](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/30)

To fix the problem, we need to ensure that any user-provided input is properly sanitized or escaped before being inserted into the HTML content. The best way to fix this issue without changing existing functionality is to use a library like `DOMPurify` to sanitize the input before setting the `innerHTML` property. This will prevent any malicious scripts from being executed.

We will need to:
1. Import the `DOMPurify` library.
2. Use `DOMPurify.sanitize` to sanitize the constructed HTML string before setting it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
