### PR TITLE
Potential fix for code scanning alert no. 44: Missing rate limiting

### DIFF
--- a/ServerProgram/package.json
+++ b/ServerProgram/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "express": "^4.20.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/44](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/44)

To fix the problem, we need to introduce rate limiting to the Express application to prevent denial-of-service attacks. The best way to do this is by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made to the server within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the package in the `ServerProgram/src/register-url-handlers.ts` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the route handler that performs file system access (`sendRequestedFile`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
