### PR TITLE
Potential fix for code scanning alert no. 52: Uncontrolled data used in path expression

### DIFF
--- a/ServerProgram/src/routing/send-file.ts
+++ b/ServerProgram/src/routing/send-file.ts
@@ -2,11 +2,20 @@ import { Request, Response } from "express";
 import { _throw } from "../stdlib";
 import { send404NotFound } from "./send-404-not-found";
 import { existsSync } from "fs";
+import * as path from "path";
+
+const ROOT = "/var/www/"; // Define the root directory
 
 export const sendFile = (req: Request, res: Response, fullpath: string) => {
-  if (existsSync(decodeURI(fullpath))) {
-    return res.sendFile(decodeURI(fullpath));
+  const normalizedPath = path.resolve(ROOT, decodeURI(fullpath));
+  if (!normalizedPath.startsWith(ROOT)) {
+    res.statusCode = 403;
+    res.end();
+    return;
   }
-  console.error(`File not Found: ${decodeURI(fullpath)}`);
+  if (existsSync(normalizedPath)) {
+    return res.sendFile(normalizedPath);
+  }
+  console.error(`File not Found: ${normalizedPath}`);
   send404NotFound(req, res);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/52](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/52)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` or `fs.realpathSync` to remove any ".." segments and then checking that the normalized path starts with the root folder. This approach will prevent directory traversal attacks by ensuring that the file path remains within the intended directory.

1. Import the `path` module in `ServerProgram/src/routing/send-file.ts`.
2. Normalize the `fullpath` using `path.resolve` and check that it starts with the `ROOT` directory.
3. If the normalized path does not start with the `ROOT` directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
