### PR TITLE
Potential fix for code scanning alert no. 53: Uncontrolled data used in path expression

### DIFF
--- a/ServerProgram/src/routing/send-file.ts
+++ b/ServerProgram/src/routing/send-file.ts
@@ -2,11 +2,20 @@ import { Request, Response } from "express";
 import { _throw } from "../stdlib";
 import { send404NotFound } from "./send-404-not-found";
 import { existsSync } from "fs";
+import * as path from "path";
+
+const ROOT = "/var/www/"; // Define the root directory
 
 export const sendFile = (req: Request, res: Response, fullpath: string) => {
-  if (existsSync(decodeURI(fullpath))) {
-    return res.sendFile(decodeURI(fullpath));
+  const normalizedPath = path.resolve(ROOT, decodeURI(fullpath));
+  if (!normalizedPath.startsWith(ROOT)) {
+    res.statusCode = 403;
+    res.end();
+    return;
   }
-  console.error(`File not Found: ${decodeURI(fullpath)}`);
+  if (existsSync(normalizedPath)) {
+    return res.sendFile(normalizedPath);
+  }
+  console.error(`File not Found: ${normalizedPath}`);
   send404NotFound(req, res);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/53](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/53)

To fix the problem, we need to ensure that the `fullpath` is validated and sanitized before it is used in the `sendFile` function. The best way to do this is to normalize the path using `path.resolve` and ensure it is contained within a safe root directory. This will prevent path traversal attacks by removing any `..` segments and ensuring the path starts with the root directory.

1. Import the `path` module in `ServerProgram/src/routing/send-file.ts`.
2. Normalize the `fullpath` using `path.resolve` and check that it starts with the root directory.
3. If the normalized path does not start with the root directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
