### PR TITLE
Potential fix for code scanning alert no. 57: Missing rate limiting

### DIFF
--- a/ServerProgram/package.json
+++ b/ServerProgram/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "express": "^4.20.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",

--- a/ServerProgram/src/register-url-handlers.ts
+++ b/ServerProgram/src/register-url-handlers.ts
@@ -1,11 +1,17 @@
 import { default as multer } from "multer";
 import { default as express } from "express";
+import RateLimit from "express-rate-limit";
 import { handlePostRequest, listUpGTTMExample, send404HTML, send404NotFound, sendRequestedFile } from "./routing";
 import { loadAnalysisFromCrepe, loadAnalysisFromPYIN, loadRomanAnalysis, renameFile } from "./handle-analyzed-data";
 import { POST_DATA_PATH } from "./constants";
 import { _throw } from "./stdlib";
 
 export const registerURLHandlers = (app: ReturnType<typeof express>) => {
+  const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+  app.use(limiter);
   const upload = multer({ dest: POST_DATA_PATH });  // multer が POST_DATA_PATH にファイルを作成
   const analyzed = `/MusicAnalyzer-server/resources/**/analyzed`;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/57](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/57)

To fix the problem, we need to introduce rate limiting to the Express application. This can be achieved by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made to the server within a specified time window. We will apply the rate limiter to all routes to ensure that the application is protected from excessive requests.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `ServerProgram/src/register-url-handlers.ts` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum 100 requests per 15 minutes).
4. Apply the rate limiter to the Express application using the `app.use` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
