### PR TITLE
Potential fix for code scanning alert no. 54: Uncontrolled command line

### DIFF
--- a/ServerProgram/package.json
+++ b/ServerProgram/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "express": "^4.20.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "shell-quote": "^1.8.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",

--- a/ServerProgram/src/handle-analyzed-data/run-process-with-cache.ts
+++ b/ServerProgram/src/handle-analyzed-data/run-process-with-cache.ts
@@ -1,4 +1,5 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+import * as shellQuote from "shell-quote";
 import { dirname } from "path";
 import { _throw } from "../stdlib";
 import { makeNewDir } from "./make-new-dir";
@@ -11,7 +12,8 @@ const _runProcessWithCache = (
   try {
     makeNewDir(dirname(dst));
     console.log(decodeURI(process));
-    execSync(decodeURI(process));
+    const processArgs = shellQuote.parse(decodeURI(process));
+    execFileSync(processArgs[0], processArgs.slice(1));
     chmodSync(decodeURI(dst), 0o775);
   } catch (e) {
     console.trace(e);


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/54](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/54)

To fix the problem, we should avoid using `execSync` with a single concatenated string that includes user input. Instead, we should use `execFileSync` or a similar API that accepts command arguments as an array of strings. This approach is safer and prevents command injection attacks. We will need to parse the `process` string into an array of arguments safely using a library like `shell-quote`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
