### PR TITLE
Potential fix for code scanning alert no. 72: Server-side URL redirect

### DIFF
--- a/ServerProgram/src/routing/send-301-redirect.ts
+++ b/ServerProgram/src/routing/send-301-redirect.ts
@@ -1,16 +1,18 @@
 import { Response } from "express";
 import { _throw  } from "../stdlib";
 
-const isLocalUrl = (url: string) => {
-  try {
-    return new URL(url, "https://example.com").origin === "https://example.com";
-  } catch (e) {
-    return false;
-  }
+const authorizedRedirects = [
+  "/home",
+  "/profile",
+  "/settings"
+];
+
+const isAuthorizedRedirect = (url: string) => {
+  return authorizedRedirects.includes(url);
 };
 
 export const send301Redirect = (res: Response, pathname: string) => {
-  if (isLocalUrl(pathname)) {
+  if (isAuthorizedRedirect(pathname)) {
     res.redirect(301, pathname);
   } else {
     res.redirect(301, "/");


### PR DESCRIPTION
Potential fix for [https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/72](https://github.com/Summer498/MusicAnalyzer-Server/security/code-scanning/72)

To fix the problem, we need to ensure that the URL used in the redirect is validated against a list of authorized redirects or is checked more rigorously to ensure it does not lead to a different host. We can maintain a list of authorized redirects on the server and choose from that list based on the user input provided. This approach will ensure that only pre-approved URLs are used for redirection.

1. Create a list of authorized redirects.
2. Validate the user input against this list before performing the redirection.
3. If the user input does not match any authorized redirect, redirect to a default safe URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
