### PR TITLE
Fix phase accumulation and add unit tests

### DIFF
--- a/packages/cli/post-f0-util/index.test.ts
+++ b/packages/cli/post-f0-util/index.test.ts
@@ -1,0 +1,11 @@
+describe("getFreqFromPhase", () => {
+  const { getFreqFromPhase } = require("./src/get-freq-from-phase");
+  test("returns cumulative phase starting with zero", () => {
+    const input = [1, 2, 3];
+    const result = getFreqFromPhase(input);
+    expect(result).toEqual([0, 1, 3]);
+  });
+  test("handles empty array", () => {
+    expect(getFreqFromPhase([])).toEqual([]);
+  });
+});

--- a/packages/cli/post-f0-util/src/get-freq-from-phase.ts
+++ b/packages/cli/post-f0-util/src/get-freq-from-phase.ts
@@ -3,6 +3,6 @@ export const getFreqFromPhase = (frequency: number[]) => {
   frequency.reduce((p, c, i) => {
     phase[i] = p;
     return p + c;
-  })
+  }, 0)
   return phase
 }


### PR DESCRIPTION
## Summary
- fix `getFreqFromPhase` so that the first phase value starts at zero
- add a dedicated test verifying the behaviour

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68413a16db388332a79a78b20912a436