### PR TITLE
Refactor median filter utility

### DIFF
--- a/CLASS_CHECKLIST.md
+++ b/CLASS_CHECKLIST.md
@@ -1,0 +1,144 @@
+- [ ] packages/UI/controllers/src/color-selector.ts -  ColorSelector<T> extends Controller<T> {
+- [ ] packages/UI/controllers/src/color-selector.ts -  IRM_ColorSelector
+- [ ] packages/UI/controllers/src/color-selector.ts -  MelodyColorController {
+- [ ] packages/UI/controllers/src/color-selector.ts -  MelodyColorSelector {
+- [ ] packages/UI/controllers/src/controller.ts -  Controller<T> {
+- [ ] packages/UI/controllers/src/controller.ts -  ControllerView {
+- [ ] packages/UI/controllers/src/melody-beep-controller.ts -  MelodyBeepController {
+- [ ] packages/UI/controllers/src/melody-beep-controller.ts -  MelodyBeepSwitcher
+- [ ] packages/UI/controllers/src/melody-beep-controller.ts -  MelodyBeepVolume
+- [ ] packages/UI/controllers/src/slider.ts -  HierarchyLevel
+- [ ] packages/UI/controllers/src/slider.ts -  HierarchyLevelController {
+- [ ] packages/UI/controllers/src/slider.ts -  Slider<T> extends Controller<T> {
+- [ ] packages/UI/controllers/src/slider.ts -  TimeRangeController {
+- [ ] packages/UI/controllers/src/slider.ts -  TimeRangeSlider
+- [ ] packages/UI/controllers/src/switcher.ts -  Checkbox extends Controller<boolean> {
+- [ ] packages/UI/controllers/src/switcher.ts -  DMelodyController {
+- [ ] packages/UI/controllers/src/switcher.ts -  GravityController {
+- [ ] packages/UI/controllers/src/switcher.ts -  ImplicationDisplayController {
+- [ ] packages/UI/piano-roll/beat-view/src/beat-elements.ts -  BeatBar {
+- [ ] packages/UI/piano-roll/beat-view/src/beat-elements.ts -  BeatBarModel {
+- [ ] packages/UI/piano-roll/beat-view/src/beat-elements.ts -  BeatBarView {
+- [ ] packages/UI/piano-roll/beat-view/src/beat-elements.ts -  BeatBarsSeries {
+- [ ] packages/UI/piano-roll/beat-view/src/beat-elements.ts -  BeatElements {
+- [ ] packages/UI/piano-roll/chord-view/index.ts -  ChordElements {
+- [ ] packages/UI/piano-roll/melody-view/index.ts -  MelodyElements {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  CacheCore {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlot {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotAxis {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotCircles {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotHierarchy {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotHierarchyModel {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotHierarchyView {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotLayer {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotLayerModel {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotLayerView {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotModel {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotSVG {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotView {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  IRPlotViewModel {
+- [ ] packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts -  MelodiesCache {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  Bracket {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  Dot {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  IRMSymbol {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  Reduction {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  ReductionHierarchy {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  ReductionLayer {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  ReductionModel {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  ReductionView {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts -  ReductionViewModel {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-tree.ts -  Line {
+- [ ] packages/UI/piano-roll/melody-view/src/reduction-tree.ts -  TreeHierarchy {
+- [ ] packages/UI/piano-roll/piano-roll/src/analysis-view.ts -  AnalysisView {
+- [ ] packages/UI/piano-roll/piano-roll/src/analysis-view.ts -  MusicStructureElements {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  BG extends Rectangle {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  BGs {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  CurrentTimeLine {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  Key extends Rectangle {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  Keys {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  PianoRoll {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  Rectangle {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  RectangleModel {
+- [ ] packages/UI/piano-roll/piano-roll/src/piano-roll.ts -  RectangleView {
+- [ ] packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts -  AudioAnalyzer {
+- [ ] packages/UI/spectrogram/src/audio-viewer.ts -  AudioViewer {
+- [ ] packages/UI/spectrogram/src/fft-viewer.ts -  FFTViewer {
+- [ ] packages/UI/spectrogram/src/spectrogram-viewer.ts -  spectrogramViewer {
+- [ ] packages/UI/spectrogram/src/wave-viewer.ts -  WaveViewer {
+- [ ] packages/UI/view-parameters/index.ts -  CurrentTimeRatio {
+- [ ] packages/UI/view-parameters/index.ts -  CurrentTimeX {
+- [ ] packages/UI/view-parameters/index.ts -  NoteSize {
+- [ ] packages/UI/view-parameters/index.ts -  NowAt {
+- [ ] packages/UI/view-parameters/index.ts -  OctaveCount {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollBegin {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollEnd {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollHeight {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollRatio {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollTimeLength {
+- [ ] packages/UI/view-parameters/index.ts -  PianoRollWidth {
+- [ ] packages/UI/view-parameters/index.ts -  SongLength {
+- [ ] packages/UI/view-parameters/index.ts -  WindowInnerWidth {
+- [ ] packages/UI/view/index.ts -  AudioReflectableRegistry {
+- [ ] packages/UI/view/index.ts -  PianoRollTranslateX {
+- [ ] packages/UI/view/index.ts -  WindowReflectableRegistry {
+- [ ] packages/cli/post-crepe/src/median-filter.ts -  MedianFilter {
+- [ ] packages/cli/post-pyin/src/median-filter.ts -  MedianFilter {
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts -  Head
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts -  ProlongationTree {
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts -  ProlongationalReduction 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts -  ProlongationalRegion 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/ReductionElement.ts -  ReductionElement {
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  At {
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  Chord 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  Temp 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  TimeSpan 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  TimeSpanReduction 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts -  TimeSpanTree 
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/common.ts -  Head<C extends Chord> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/analysis-result/gttm-data.ts -  GTTMData {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr1.ts -  GPR1 {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr2a.ts -  GPR2a<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr2b.ts -  GPR2b<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts -  GPR3a<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts -  GPR3b<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts -  GPR3c<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts -  GPR3d<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Interval.ts -  IntervalOfTime<Time> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Note.ts -  Note<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Pair.ts -  Pair<T> extends Negatable {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Transition.ts -  IntervallicDistance<T> {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Transition.ts -  Transition<T> extends Negatable {
+- [ ] packages/cognitive-theory-of-music/gttm/src/preference-rules/common/create-negated.ts -  Negatable {
+- [ ] packages/data-type/serializable-data/src/json-serializable.ts -  JSONSerializable<T extends JSONSerializable<T>> extends Serializable<T> {
+- [ ] packages/data-type/serializable-data/src/serializable.ts -  Serializable<T extends Serializable<T>> 
+- [ ] packages/data-type/serializable-data/src/xml-serializable.ts -  XMLSerializable<T extends XMLSerializable<T>> extends Serializable<T> {
+- [ ] packages/music-structure/analyzed-data-container/src/analyze-data-container.ts -  AnalyzedDataContainer {
+- [ ] packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts -  SerializedRomanAnalysisData {
+- [ ] packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts -  SerializedTimeAndRomanAnalysis {
+- [ ] packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts -  with the constructor which has 1 argument
+- [ ] packages/music-structure/chord/chord-analyze/src/chord-analyze/time-and-chord.ts -  TimeAndChordSymbol {
+- [ ] packages/music-structure/chord/chord-analyze/src/key-estimation/chord-progression.ts -  ChordProgression {
+- [ ] packages/music-structure/chord/roman-chord/src/roman-chord.ts -  RomanChord {
+- [ ] packages/music-structure/melody/melody-analyze/index.ts -  Gravity {
+- [ ] packages/music-structure/melody/melody-analyze/index.ts -  SerializedMelodyAnalysis {
+- [ ] packages/music-structure/melody/melody-analyze/index.ts -  SerializedMelodyAnalysisData {
+- [ ] packages/music-structure/melody/melody-analyze/index.ts -  SerializedTimeAndAnalyzedMelody {
+- [ ] packages/music-structure/melody/melody-analyze/index.ts -  TimeAndMelody {
+- [ ] packages/music-structure/melody/melody-analyze/src/serialized-gravity.ts -  SerializedGravity {
+- [ ] packages/music-structure/melody/melody-analyze/src/serialized-melody-analysis-data.ts -  SerializedMelodyAnalysisData {
+- [ ] packages/music-structure/melody/melody-analyze/src/serialized-melody-analysis.ts -  SerializedMelodyAnalysis {
+- [ ] packages/music-structure/melody/melody-analyze/src/serialized-time-and-analyzed-melody.ts -  SerializedTimeAndAnalyzedMelody {
+- [ ] packages/music-structure/melody/melody-analyze/src/time-and-chord.ts -  TimeAndChord {
+- [ ] packages/music-structure/melody/melody-analyze/src/time-and-melody.ts -  TimeAndMelody {
+- [ ] packages/music-structure/melody/melody-hierarchical-analysis/index.ts -  SerializedTimeAndAnalyzedMelodyAndIR
+- [ ] packages/util/graph/src/viterbi-core.ts -  LogViterbiResult<S> {
+- [ ] packages/util/graph/src/viterbi.ts -  ViterbiResult<S> {
+- [ ] packages/util/html/src/html.ts -  HTML {
+- [ ] packages/util/html/src/svg.ts -  SVG {
+- [ ] packages/util/math/src/fft/array/root-of-unity.ts -  RootOfUnity {
+- [ ] packages/util/math/src/fft/complex.ts -  Complex<T extends number> {
+- [ ] packages/util/math/src/fft/root-of-unity.ts -  RootOfUnity {
+- [ ] packages/util/math/src/reduction/compare.ts -  Compare {
+- [ ] packages/util/stdlib/src/assertion/assertion.ts -  Assertion {
+- [ ] packages/util/stdlib/src/error/not-implemented-error.ts -  NotImplementedError 
+- [ ] packages/util/time-and/src/time.ts -  Time {

--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ and roman–numeral data and outputs analysis results.
 
 These commands operate from the repository root and leverage the Yarn workspace
 configuration.
+
+### Creating utility instances
+
+Some CLI utilities expose factory functions rather than classes. For example,
+the median filter used in post-processing is constructed with
+`createMedianFilter()`:
+
+```ts
+import { createMedianFilter } from "@music-analyzer/post-pyin";
+const filter = createMedianFilter(25);
+```
+
+This pattern replaces the previous `new MedianFilter()` usage and helps remove
+class declarations from the codebase.

--- a/class-list.txt
+++ b/class-list.txt
@@ -1,0 +1,144 @@
+packages/UI/controllers/src/color-selector.ts: ColorSelector<T> extends Controller<T> {
+packages/UI/controllers/src/color-selector.ts: IRM_ColorSelector
+packages/UI/controllers/src/color-selector.ts: MelodyColorController {
+packages/UI/controllers/src/color-selector.ts: MelodyColorSelector {
+packages/UI/controllers/src/controller.ts: Controller<T> {
+packages/UI/controllers/src/controller.ts: ControllerView {
+packages/UI/controllers/src/melody-beep-controller.ts: MelodyBeepController {
+packages/UI/controllers/src/melody-beep-controller.ts: MelodyBeepSwitcher
+packages/UI/controllers/src/melody-beep-controller.ts: MelodyBeepVolume
+packages/UI/controllers/src/slider.ts: HierarchyLevel
+packages/UI/controllers/src/slider.ts: HierarchyLevelController {
+packages/UI/controllers/src/slider.ts: Slider<T> extends Controller<T> {
+packages/UI/controllers/src/slider.ts: TimeRangeController {
+packages/UI/controllers/src/slider.ts: TimeRangeSlider
+packages/UI/controllers/src/switcher.ts: Checkbox extends Controller<boolean> {
+packages/UI/controllers/src/switcher.ts: DMelodyController {
+packages/UI/controllers/src/switcher.ts: GravityController {
+packages/UI/controllers/src/switcher.ts: ImplicationDisplayController {
+packages/UI/piano-roll/beat-view/src/beat-elements.ts: BeatBar {
+packages/UI/piano-roll/beat-view/src/beat-elements.ts: BeatBarModel {
+packages/UI/piano-roll/beat-view/src/beat-elements.ts: BeatBarView {
+packages/UI/piano-roll/beat-view/src/beat-elements.ts: BeatBarsSeries {
+packages/UI/piano-roll/beat-view/src/beat-elements.ts: BeatElements {
+packages/UI/piano-roll/chord-view/index.ts: ChordElements {
+packages/UI/piano-roll/melody-view/index.ts: MelodyElements {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: CacheCore {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlot {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotAxis {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotCircles {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotHierarchy {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotHierarchyModel {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotHierarchyView {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotLayer {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotLayerModel {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotLayerView {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotModel {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotSVG {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotView {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: IRPlotViewModel {
+packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts: MelodiesCache {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: Bracket {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: Dot {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: IRMSymbol {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: Reduction {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: ReductionHierarchy {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: ReductionLayer {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: ReductionModel {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: ReductionView {
+packages/UI/piano-roll/melody-view/src/reduction-hierarchy.ts: ReductionViewModel {
+packages/UI/piano-roll/melody-view/src/reduction-tree.ts: Line {
+packages/UI/piano-roll/melody-view/src/reduction-tree.ts: TreeHierarchy {
+packages/UI/piano-roll/piano-roll/src/analysis-view.ts: AnalysisView {
+packages/UI/piano-roll/piano-roll/src/analysis-view.ts: MusicStructureElements {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: BG extends Rectangle {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: BGs {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: CurrentTimeLine {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: Key extends Rectangle {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: Keys {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: PianoRoll {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: Rectangle {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: RectangleModel {
+packages/UI/piano-roll/piano-roll/src/piano-roll.ts: RectangleView {
+packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts: AudioAnalyzer {
+packages/UI/spectrogram/src/audio-viewer.ts: AudioViewer {
+packages/UI/spectrogram/src/fft-viewer.ts: FFTViewer {
+packages/UI/spectrogram/src/spectrogram-viewer.ts: spectrogramViewer {
+packages/UI/spectrogram/src/wave-viewer.ts: WaveViewer {
+packages/UI/view-parameters/index.ts: CurrentTimeRatio {
+packages/UI/view-parameters/index.ts: CurrentTimeX {
+packages/UI/view-parameters/index.ts: NoteSize {
+packages/UI/view-parameters/index.ts: NowAt {
+packages/UI/view-parameters/index.ts: OctaveCount {
+packages/UI/view-parameters/index.ts: PianoRollBegin {
+packages/UI/view-parameters/index.ts: PianoRollEnd {
+packages/UI/view-parameters/index.ts: PianoRollHeight {
+packages/UI/view-parameters/index.ts: PianoRollRatio {
+packages/UI/view-parameters/index.ts: PianoRollTimeLength {
+packages/UI/view-parameters/index.ts: PianoRollWidth {
+packages/UI/view-parameters/index.ts: SongLength {
+packages/UI/view-parameters/index.ts: WindowInnerWidth {
+packages/UI/view/index.ts: AudioReflectableRegistry {
+packages/UI/view/index.ts: PianoRollTranslateX {
+packages/UI/view/index.ts: WindowReflectableRegistry {
+packages/cli/post-crepe/src/median-filter.ts: MedianFilter {
+packages/cli/post-pyin/src/median-filter.ts: MedianFilter {
+packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts: Head
+packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts: ProlongationTree {
+packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts: ProlongationalReduction 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/PR.ts: ProlongationalRegion 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/ReductionElement.ts: ReductionElement {
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: At {
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: Chord 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: Temp 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: TimeSpan 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: TimeSpanReduction 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/TSR.ts: TimeSpanTree 
+packages/cognitive-theory-of-music/gttm/src/analysis-result/common.ts: Head<C extends Chord> {
+packages/cognitive-theory-of-music/gttm/src/analysis-result/gttm-data.ts: GTTMData {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr1.ts: GPR1 {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr2a.ts: GPR2a<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr2b.ts: GPR2b<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts: GPR3a<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts: GPR3b<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts: GPR3c<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/GPR/gpr3.ts: GPR3d<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Interval.ts: IntervalOfTime<Time> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Note.ts: Note<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Pair.ts: Pair<T> extends Negatable {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Transition.ts: IntervallicDistance<T> {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/Transition.ts: Transition<T> extends Negatable {
+packages/cognitive-theory-of-music/gttm/src/preference-rules/common/create-negated.ts: Negatable {
+packages/data-type/serializable-data/src/json-serializable.ts: JSONSerializable<T extends JSONSerializable<T>> extends Serializable<T> {
+packages/data-type/serializable-data/src/serializable.ts: Serializable<T extends Serializable<T>> 
+packages/data-type/serializable-data/src/xml-serializable.ts: XMLSerializable<T extends XMLSerializable<T>> extends Serializable<T> {
+packages/music-structure/analyzed-data-container/src/analyze-data-container.ts: AnalyzedDataContainer {
+packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts: SerializedRomanAnalysisData {
+packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts: SerializedTimeAndRomanAnalysis {
+packages/music-structure/chord/chord-analyze/src/chord-analyze/serialized-time-and-roman-analysis.ts: with the constructor which has 1 argument
+packages/music-structure/chord/chord-analyze/src/chord-analyze/time-and-chord.ts: TimeAndChordSymbol {
+packages/music-structure/chord/chord-analyze/src/key-estimation/chord-progression.ts: ChordProgression {
+packages/music-structure/chord/roman-chord/src/roman-chord.ts: RomanChord {
+packages/music-structure/melody/melody-analyze/index.ts: Gravity {
+packages/music-structure/melody/melody-analyze/index.ts: SerializedMelodyAnalysis {
+packages/music-structure/melody/melody-analyze/index.ts: SerializedMelodyAnalysisData {
+packages/music-structure/melody/melody-analyze/index.ts: SerializedTimeAndAnalyzedMelody {
+packages/music-structure/melody/melody-analyze/index.ts: TimeAndMelody {
+packages/music-structure/melody/melody-analyze/src/serialized-gravity.ts: SerializedGravity {
+packages/music-structure/melody/melody-analyze/src/serialized-melody-analysis-data.ts: SerializedMelodyAnalysisData {
+packages/music-structure/melody/melody-analyze/src/serialized-melody-analysis.ts: SerializedMelodyAnalysis {
+packages/music-structure/melody/melody-analyze/src/serialized-time-and-analyzed-melody.ts: SerializedTimeAndAnalyzedMelody {
+packages/music-structure/melody/melody-analyze/src/time-and-chord.ts: TimeAndChord {
+packages/music-structure/melody/melody-analyze/src/time-and-melody.ts: TimeAndMelody {
+packages/music-structure/melody/melody-hierarchical-analysis/index.ts: SerializedTimeAndAnalyzedMelodyAndIR
+packages/util/graph/src/viterbi-core.ts: LogViterbiResult<S> {
+packages/util/graph/src/viterbi.ts: ViterbiResult<S> {
+packages/util/html/src/html.ts: HTML {
+packages/util/html/src/svg.ts: SVG {
+packages/util/math/src/fft/array/root-of-unity.ts: RootOfUnity {
+packages/util/math/src/fft/complex.ts: Complex<T extends number> {
+packages/util/math/src/fft/root-of-unity.ts: RootOfUnity {
+packages/util/math/src/reduction/compare.ts: Compare {
+packages/util/stdlib/src/assertion/assertion.ts: Assertion {
+packages/util/stdlib/src/error/not-implemented-error.ts: NotImplementedError 
+packages/util/time-and/src/time.ts: Time {

--- a/packages/cli/post-crepe/src/get-median-frequency.ts
+++ b/packages/cli/post-crepe/src/get-median-frequency.ts
@@ -1,9 +1,9 @@
 import { getRange } from "@music-analyzer/math";
-import { MedianFilter } from "./median-filter";
+import { createMedianFilter } from "./median-filter";
 
 export const getMedianFrequency = (freq_rounded: number[]) => {
   // 中央値を用いたフィルタ (ヘンペルフィルタ) を用いてスパイクノイズを除去する
   const WINDOW_SIZE = 25;
-  const median_filter = new MedianFilter(freq_rounded, WINDOW_SIZE);
+  const median_filter = createMedianFilter(freq_rounded, WINDOW_SIZE);
   return getRange(0, freq_rounded.length).map(i => median_filter.median(i));
 };

--- a/packages/cli/post-crepe/src/index.ts
+++ b/packages/cli/post-crepe/src/index.ts
@@ -1,3 +1,4 @@
 export { getMedianFrequency } from "./get-median-frequency";
+export { createMedianFilter } from "./median-filter";
 
 export type VocalsF0CSV = { time: number, frequency: number, confidence: number }

--- a/packages/cli/post-crepe/src/median-filter.ts
+++ b/packages/cli/post-crepe/src/median-filter.ts
@@ -1,17 +1,19 @@
 import { median } from "@music-analyzer/math";
 
-export class MedianFilter {
-  readonly buff;
-  readonly array;
-  constructor(
-    initializer: number[],
-    readonly window_size: number,
-  ) {
-    this.buff = initializer.slice(0, window_size);
-    this.array = initializer;
-  }
-  median(i: number) {
-    this.buff[i % this.window_size] = this.array[i];  // リングバッファに保存
-    return median(this.buff);
-  }
+export interface MedianFilter {
+  median(i: number): number;
 }
+
+export const createMedianFilter = (
+  initializer: number[],
+  window_size: number,
+): MedianFilter => {
+  const buff = initializer.slice(0, window_size);
+  const array = initializer;
+  return {
+    median(i: number) {
+      buff[i % window_size] = array[i];  // リングバッファに保存
+      return median(buff);
+    },
+  };
+};

--- a/packages/cli/post-pyin/src/get-median-frequency.ts
+++ b/packages/cli/post-pyin/src/get-median-frequency.ts
@@ -1,8 +1,8 @@
-import { MedianFilter } from "./median-filter";
+import { createMedianFilter } from "./median-filter";
 
 export const getMedianFrequency = (freq_rounded: (number | null)[]) => {
   // 中央値を用いたフィルタ (ヘンペルフィルタ) を用いてスパイクノイズを除去する
   const WINDOW_SIZE = 25;
-  const median_filter = new MedianFilter(WINDOW_SIZE);
+  const median_filter = createMedianFilter(WINDOW_SIZE);
   return freq_rounded.map(e => median_filter.median(e));
 };

--- a/packages/cli/post-pyin/src/index.ts
+++ b/packages/cli/post-pyin/src/index.ts
@@ -1,2 +1,3 @@
 export { getMedianFrequency } from "./get-median-frequency";
+export { createMedianFilter } from "./median-filter";
 export { Vocals } from "./pyin-output-type";

--- a/packages/cli/post-pyin/src/median-filter.ts
+++ b/packages/cli/post-pyin/src/median-filter.ts
@@ -1,29 +1,31 @@
 import { median } from "@music-analyzer/math";
 
-export class MedianFilter {
-  i;
-  buff: number[];
-  constructor(
-    readonly window_size: number,
-  ) {
-    this.i = 0;
-    this.buff = [];
-  }
-  median(e: number | null) {
-    // i が 1 ずつ上がる想定
-    if (e === null) {
-      // バッファ初期化
-      this.i = 0;
-      this.buff = [];
-      return null;
-    }
+export interface MedianFilter {
+  median(e: number | null): number | null;
+}
 
-    if (this.buff.length < this.window_size) { this.buff.push(e); }
+export const createMedianFilter = (
+  window_size: number,
+): MedianFilter => {
+  let i = 0;
+  let buff: number[] = [];
+  return {
+    median(e: number | null) {
+      // i が 1 ずつ上がる想定
+      if (e === null) {
+        // バッファ初期化
+      i = 0;
+      buff = [];
+        return null;
+      }
+
+    if (buff.length < window_size) { buff.push(e); }
     else {
       // リングバッファに保存
-      this.i = (this.i + 1) % this.window_size;
-      this.buff[this.i] = e;
+      i = (i + 1) % window_size;
+      buff[i] = e;
     }
-    return median(this.buff);
-  }
-}
+    return median(buff);
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- generate checklist for remaining classes to refactor
- convert post-pyin and post-crepe MedianFilter classes to factory functions
- adjust imports/exports for the new factory API
- document factory usage in README

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find name 'test', etc.)*
- `npx jest --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841429aa0dc8332a43cff22b41ab5e1