### PR TITLE
Replace Assertion constructor with createAssertion

### DIFF
--- a/packages/cognitive-theory-of-music/tonal-pitch-space/src/get-basic-space.ts
+++ b/packages/cognitive-theory-of-music/tonal-pitch-space/src/get-basic-space.ts
@@ -3,17 +3,17 @@ import { getTonicChroma } from "./get-tonic-chroma";
 import { getPowerChroma } from "./get-power-chroma";
 import { getChordChroma } from "./get-chord-chroma";
 import { getScaleChroma } from "./get-scale-chroma";
-import { Assertion } from "@music-analyzer/stdlib";
+import { createAssertion } from "@music-analyzer/stdlib";
 import { getOnehot } from "@music-analyzer/math";
 import { vSum } from "@music-analyzer/math";
 
 export const getBasicSpace = (roman: RomanChord) => {
-  new Assertion(!roman.scale.empty).onFailed(() => {
+  createAssertion(!roman.scale.empty).onFailed(() => {
     console.log(`received:`);
     console.log(roman.scale);
     throw new Error("scale must not be empty");
   });
-  new Assertion(!roman.chord.empty).onFailed(() => {
+  createAssertion(!roman.chord.empty).onFailed(() => {
     console.log(`received:`);
     console.log(roman.chord);
     throw new Error("chord must not be empty");

--- a/packages/cognitive-theory-of-music/tonal-pitch-space/src/get-power-chroma.ts
+++ b/packages/cognitive-theory-of-music/tonal-pitch-space/src/get-power-chroma.ts
@@ -1,4 +1,4 @@
-import { Assertion } from "@music-analyzer/stdlib";
+import { createAssertion } from "@music-analyzer/stdlib";
 import { assertNonNullable as NN } from "@music-analyzer/stdlib";
 import { Chord } from "@music-analyzer/tonal-objects";
 import { getIntervalDegree } from "@music-analyzer/tonal-objects";
@@ -7,7 +7,7 @@ import { getChroma } from "@music-analyzer/tonal-objects";
 export const getPowerChroma = (chord: Chord) => {
   const tonic = NN(chord.tonic);
   const fifths = chord.notes.filter(note => getIntervalDegree(tonic, note) == 5);
-  new Assertion(fifths.length == 1).onFailed(() => {
+  createAssertion(fifths.length == 1).onFailed(() => {
     console.log(`received:`);
     console.log(chord.notes);
     throw new Error("received chord must have just one 5th code.");

--- a/packages/music-structure/chord/chord-analyze/src/key-estimation/get-chord.ts
+++ b/packages/music-structure/chord/chord-analyze/src/key-estimation/get-chord.ts
@@ -1,7 +1,7 @@
 import { Chord } from "@music-analyzer/tonal-objects";
 import { getChord as _getChord } from "@music-analyzer/tonal-objects";
 import { getIntervalDegree } from "@music-analyzer/tonal-objects";
-import { Assertion } from "@music-analyzer/stdlib";
+import { createAssertion } from "@music-analyzer/stdlib";
 import { getBodyAndRoot } from "./get-body-and-root";
 
 // ルート付きコードが入力されてもコードを得られるようにする.
@@ -11,7 +11,7 @@ export const getChord = (chord_string: string) => {
   const chord = _getChord(body_and_root.body);
   if (chord_string === "") { return chord; }
 
-  new Assertion(!chord.empty).onFailed(() => { throw Error(`Illegal chord symbol "${chord_string}" received`); });
+  createAssertion(!chord.empty).onFailed(() => { throw Error(`Illegal chord symbol "${chord_string}" received`); });
   // new Assertion(chord.tonic != null).onFailed(() => { throw new TypeError("tonic must not be null"); });  // NOTE: chord.tonic を null にするテストケースを思いつかないので(=無さそうなので)コメントアウト
 
   if (root != "" && !chord.notes.includes(root)) {


### PR DESCRIPTION
## Summary
- use `createAssertion` from `@music-analyzer/stdlib`
- replace `new Assertion` usages

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6842389e22d883329b58f5d66c4fe687