### PR TITLE
Add util package aliases to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,17 @@
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist",
+    "baseUrl": ".",
     "paths": {
       "@music-analyzer/chord-analyze": ["./packages/chord/chord-analyze"],
       "@music-analyzer/chord-view": ["./packages/chord/chord-view"],
       "@music-analyzer/melody-view": ["./packages/melody/melody-view"],
+      "@music-analyzer/stdlib/*": ["./packages/util/stdlib/*"],
+      "@music-analyzer/color/*": ["./packages/util/color/*"],
+      "@music-analyzer/graph/*": ["./packages/util/graph/*"],
+      "@music-analyzer/html/*": ["./packages/util/html/*"],
+      "@music-analyzer/math/*": ["./packages/util/math/*"],
+      "@music-analyzer/time-and/*": ["./packages/util/time-and/*"]
     }
   },
   "exclude": ["**/dist/*"]


### PR DESCRIPTION
## Summary
- configure `baseUrl` in `tsconfig.json`
- map util package aliases in the root TypeScript config

## Testing
- `npx tsc -p tsconfig.json`
- `yarn test --runInBand` *(fails: AudioContext is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842389b4e608332b45999a16f54149f