### PR TITLE
Add Jest types to tsconfig

### DIFF
--- a/ServerProgram/tsconfig.json
+++ b/ServerProgram/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/html/analyze/tsconfig.json
+++ b/html/analyze/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/html/tsconfig.json
+++ b/html/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/controllers/tsconfig.json
+++ b/packages/UI/controllers/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/piano-roll/beat-view/tsconfig.json
+++ b/packages/UI/piano-roll/beat-view/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/piano-roll/chord-view/tsconfig.json
+++ b/packages/UI/piano-roll/chord-view/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/piano-roll/melody-view/tsconfig.json
+++ b/packages/UI/piano-roll/melody-view/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/piano-roll/piano-roll/tsconfig.json
+++ b/packages/UI/piano-roll/piano-roll/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/spectrogram/tsconfig.json
+++ b/packages/UI/spectrogram/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/synth/tsconfig.json
+++ b/packages/UI/synth/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/view-parameters/tsconfig.json
+++ b/packages/UI/view-parameters/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/UI/view/tsconfig.json
+++ b/packages/UI/view/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/_packagetemplate/tsconfig.json
+++ b/packages/_packagetemplate/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cli/chord-analyze-cli/tsconfig.json
+++ b/packages/cli/chord-analyze-cli/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cli/melody-analyze-cli/tsconfig.json
+++ b/packages/cli/melody-analyze-cli/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cli/post-crepe/tsconfig.json
+++ b/packages/cli/post-crepe/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cli/post-f0-util/tsconfig.json
+++ b/packages/cli/post-f0-util/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cognitive-theory-of-music/gttm/tsconfig.json
+++ b/packages/cognitive-theory-of-music/gttm/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cognitive-theory-of-music/irm/tsconfig.json
+++ b/packages/cognitive-theory-of-music/irm/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/cognitive-theory-of-music/tonal-pitch-space/tsconfig.json
+++ b/packages/cognitive-theory-of-music/tonal-pitch-space/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/data-type/music-xml/tsconfig.json
+++ b/packages/data-type/music-xml/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/data-type/serializable-data/tsconfig.json
+++ b/packages/data-type/serializable-data/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/music-structure/analyzed-data-container/tsconfig.json
+++ b/packages/music-structure/analyzed-data-container/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/music-structure/beat/beat-estimation/tsconfig.json
+++ b/packages/music-structure/beat/beat-estimation/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/music-structure/chord/chord-analyze/tsconfig.json
+++ b/packages/music-structure/chord/chord-analyze/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/music-structure/melody/melody-analyze/tsconfig.json
+++ b/packages/music-structure/melody/melody-analyze/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/music-structure/melody/melody-hierarchical-analysis/tsconfig.json
+++ b/packages/music-structure/melody/melody-hierarchical-analysis/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/tonal-objects/tsconfig.json
+++ b/packages/tonal-objects/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/color/tsconfig.json
+++ b/packages/util/color/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/graph/tsconfig.json
+++ b/packages/util/graph/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/html/tsconfig.json
+++ b/packages/util/html/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/math/tsconfig.json
+++ b/packages/util/math/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/stdlib/tsconfig.json
+++ b/packages/util/stdlib/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/packages/util/time-and/tsconfig.json
+++ b/packages/util/time-and/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "types": ["jest"],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist",


### PR DESCRIPTION
## Summary
- register Jest's types in each `tsconfig.json` so that TypeScript recognizes Jest globals

## Testing
- `npx tsc --noEmit -p tsconfig.json` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6842389cb0248332a93d8789d3bfd32b