### PR TITLE
Update time-and tests to use createTime

### DIFF
--- a/packages/util/time-and/index.test.ts
+++ b/packages/util/time-and/index.test.ts
@@ -1,8 +1,8 @@
-import { Time, compress, search_items_begins_in_range, search_items_overlaps_range } from "./index";
+import { createTime, Time, compress, search_items_begins_in_range, search_items_overlaps_range } from "./index";
 
 describe("Time class", () => {
   test("duration and mapping", () => {
-    const t = new Time(1, 3);
+    const t = createTime(1, 3);
     expect(t.duration).toBe(2);
     const doubled = t.map(x => x * 2);
     expect(doubled.begin).toBe(2);
@@ -10,7 +10,7 @@ describe("Time class", () => {
   });
 
   test("has method", () => {
-    const t = new Time(1, 3);
+    const t = createTime(1, 3);
     expect(t.has(2)).toBe(true);
     expect(t.has(3)).toBe(false);
   });
@@ -20,27 +20,27 @@ describe("compress", () => {
   test("groups consecutive items", () => {
     const result = compress(["a", "a", "b", "b", "b"]);
     expect(result).toEqual([
-      { time: new Time(0, 2), item: "a" },
-      { time: new Time(2, 5), item: "b" },
+      { time: createTime(0, 2), item: "a" },
+      { time: createTime(2, 5), item: "b" },
     ]);
   });
 });
 
 describe("search functions", () => {
   const items = [
-    { time: new Time(0, 1) },
-    { time: new Time(2, 3) },
-    { time: new Time(4, 5) },
+    { time: createTime(0, 1) },
+    { time: createTime(2, 3) },
+    { time: createTime(4, 5) },
   ];
 
   test("search_items_begins_in_range", () => {
-    const { begin_index, end_index } = search_items_begins_in_range(items, new Time(1, 4));
+    const { begin_index, end_index } = search_items_begins_in_range(items, createTime(1, 4));
     expect(begin_index).toBe(1);
     expect(end_index).toBe(2);
   });
 
   test("search_items_overlaps_range", () => {
-    const { begin_index, end_index } = search_items_overlaps_range(items, new Time(1.5, 4.5));
+    const { begin_index, end_index } = search_items_overlaps_range(items, createTime(1.5, 4.5));
     expect(begin_index).toBe(1);
     expect(end_index).toBe(3);
   });


### PR DESCRIPTION
## Summary
- use `createTime` in `time-and` tests

## Testing
- `yarn test` *(fails: The error below may be caused by using the wrong test environment...)*
- `npx jest packages/util/time-and/index.test.ts` *(fails: groups consecutive items)*

------
https://chatgpt.com/codex/tasks/task_e_6842389fbf9883328b54786aff4aa87b