### PR TITLE
Fix parameter type in setComponentsToElement

### DIFF
--- a/packages/util/html/src/set-components-to-element.ts
+++ b/packages/util/html/src/set-components-to-element.ts
@@ -12,6 +12,7 @@ export function setComponentsToElement<T extends Element>(
     element.setAttribute(key, String(attributes[key]));
   }
   text && element.appendChild(document.createTextNode(text));
-  children && Arraying(children).forEach(child => element.appendChild(child));
+  children &&
+    Arraying(children).forEach((child: Element) => element.appendChild(child));
   return element;
 }


### PR DESCRIPTION
## Summary
- add missing type annotation in `set-components-to-element.ts`

## Testing
- `npx tsc packages/util/html/src/set-components-to-element.ts --noEmit --pretty false`
- `npm test` *(fails: Module, Assertion, document undefined, AudioContext not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684238a118ec83328c8f05344a9f7c1c