### PR TITLE
Fix missing import in tonal pitch space test

### DIFF
--- a/packages/cognitive-theory-of-music/tonal-pitch-space/index.test.ts
+++ b/packages/cognitive-theory-of-music/tonal-pitch-space/index.test.ts
@@ -21,6 +21,7 @@ import { regionDistance } from "./src/region-distance"
 import { getBasicSpace } from "./src/get-basic-space"
 import { basicSpaceDistance } from "./src/basic-space-distance"
 import { getKeysIncludeTheChord, } from "./src/get-keys-include-the-chord"
+import * as Module from "./index"
 
 describe("tonal-pitch-space module", () => {
   test("should load module", () => {


### PR DESCRIPTION
## Summary
- add missing `Module` import in `tonal-pitch-space` tests

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684238a268848332818d32dbfab6cfbb