### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ and roman–numeral data and outputs analysis results.
 
 These commands operate from the repository root and leverage the Yarn workspace
 configuration.
+**Note for new contributors**: Run `yarn install` (or `npm install`) before using `tsc` or running the tests. Running `yarn` creates a `yarn.lock` file for repeatable installs.
 
 ### Creating utility instances
 


### PR DESCRIPTION
## Summary
- clarify that `yarn install`/`npm install` should be run before using `tsc` or tests
- mention `yarn.lock` for repeatable installs

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684238a471688332bc16b25f879a31cf