### PR TITLE
Refactor controller base types

### DIFF
--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,10 +1,10 @@
 export { SetColor } from "./src/color-selector";
 export { MelodyColorController } from "./src/color-selector";
-export { ControllerView } from "./src/controller";
+export { ControllerView, createControllerView } from "./src/controller";
 export { MelodyBeepController } from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";
 export { TimeRangeController } from "./src/slider";
-export { Controller } from "./src/controller";
+export { Controller, createController } from "./src/controller";
 export { DMelodyController } from "./src/switcher";
 export { Slider } from "./src/slider";
 export { GravityController } from "./src/switcher";

--- a/packages/UI/controllers/src/color-selector.ts
+++ b/packages/UI/controllers/src/color-selector.ts
@@ -5,18 +5,23 @@ import { get_color_on_digital_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_intervallic_angle } from "@music-analyzer/irm";
 import { get_color_on_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_registral_scale } from "@music-analyzer/irm";
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
 
 export type GetColor = (e: ITriad) => string;
 export type SetColor = (getColor: GetColor) => void;
 
-abstract class ColorSelector<T> extends Controller<T> {
+abstract class ColorSelector<T> implements Controller<T> {
+  body!: HTMLSpanElement;
+  input!: HTMLInputElement;
+  listeners!: ((e: T) => void)[];
+  addListeners!: (...listeners: ((e: T) => void)[]) => void;
+  init!: () => void;
   constructor(
     readonly id: string,
     text: string
   ) {
-    super("radio", id, text);
+    createController<T>(this, "radio", id, text);
   };
 }
 

--- a/packages/UI/controllers/src/controller.ts
+++ b/packages/UI/controllers/src/controller.ts
@@ -1,53 +1,84 @@
-type HTMLInputElementType = "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file" | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset" | "search" | "submit" | "tel" | "text" | "time" | "url" | "week";
-
-export abstract class Controller<T> {
-  readonly body: HTMLSpanElement;
-  readonly input: HTMLInputElement;
-  constructor(
-    type: HTMLInputElementType,
-    id: string,
-    label: string,
-  ) {
-    const e = new ControllerView(type, id, label);
-    this.body = e.body;
-    this.input = e.input
-    this.init()
-  }
-  protected readonly listeners: ((e:T) => void)[] = []
-  addListeners(...listeners: ((e:T) => void)[]) {
-    this.listeners.push(...listeners);
-    this.update();
-  }
-  abstract update(): void;
-  init() {
-    this.input.addEventListener("input", this.update.bind(this));
-    this.update();
-  };
+type HTMLInputElementType =
+  | "button"
+  | "checkbox"
+  | "color"
+  | "date"
+  | "datetime-local"
+  | "email"
+  | "file"
+  | "hidden"
+  | "image"
+  | "month"
+  | "number"
+  | "password"
+  | "radio"
+  | "range"
+  | "reset"
+  | "search"
+  | "submit"
+  | "tel"
+  | "text"
+  | "time"
+  | "url"
+  | "week";
+export interface Controller<T> {
+  body: HTMLSpanElement;
+  input: HTMLInputElement;
+  listeners: ((e: T) => void)[];
+  addListeners: (...listeners: ((e: T) => void)[]) => void;
+  update: () => void;
+  init: () => void;
 }
 
-export class ControllerView {
-  readonly body: HTMLSpanElement;
-  readonly input: HTMLInputElement;
-  readonly label: HTMLLabelElement;
+export interface ControllerView {
+  body: HTMLSpanElement;
+  input: HTMLInputElement;
+  label: HTMLLabelElement;
+}
 
-  constructor(
-    type: HTMLInputElementType,
-    id: string,
-    label: string,
-  ) {
-    this.input = document.createElement("input");
-    this.input.type = type;
-    this.input.id = id;
-    this.input.name = id;
+export function createControllerView(
+  type: HTMLInputElementType,
+  id: string,
+  label: string,
+): ControllerView {
+  const input = document.createElement("input");
+  input.type = type;
+  input.id = id;
+  input.name = id;
 
-    this.label = document.createElement("label");
-    this.label.textContent = label;
-    this.label.htmlFor = this.input.id;
-    this.label.style.whiteSpace = "nowrap";
+  const labelElement = document.createElement("label");
+  labelElement.textContent = label;
+  labelElement.htmlFor = input.id;
+  labelElement.style.whiteSpace = "nowrap";
 
-    this.body = document.createElement("span");
-    this.body.style.whiteSpace = "nowrap";
-    this.body.appendChild(this.label);
-    this.body.appendChild(this.input);
+  const body = document.createElement("span");
+  body.style.whiteSpace = "nowrap";
+  body.appendChild(labelElement);
+  body.appendChild(input);
+
+  return { body, input, label: labelElement };
+}
+
+export function createController<T>(
+  instance: { update: () => void } & Partial<Controller<T>>,
+  type: HTMLInputElementType,
+  id: string,
+  label: string,
+): Controller<T> {
+  const view = createControllerView(type, id, label);
+  const listeners: ((e: T) => void)[] = [];
+
+  function addListeners(...ls: ((e: T) => void)[]) {
+    listeners.push(...ls);
+    instance.update();
   }
+
+  function init() {
+    view.input.addEventListener("input", instance.update.bind(instance));
+    instance.update();
+  }
+
+  Object.assign(instance, view, { listeners, addListeners, init });
+  init();
+  return instance as Controller<T>;
 }

--- a/packages/UI/controllers/src/slider.ts
+++ b/packages/UI/controllers/src/slider.ts
@@ -1,10 +1,15 @@
 import { PianoRollRatio } from "@music-analyzer/view-parameters";
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
-export abstract class Slider<T> extends Controller<T> {
+export abstract class Slider<T> implements Controller<T> {
+  body!: HTMLSpanElement;
+  input!: HTMLInputElement;
+  listeners!: ((e: T) => void)[];
+  addListeners!: (...listeners: ((e: T) => void)[]) => void;
+  init!: () => void;
   readonly display: HTMLSpanElement;
   constructor(id: string, label: string, min: number, max: number, step: number, value?: number) {
-    super ("range", id, label);
+    createController<T>(this, "range", id, label);
     this.display = document.createElement("span");
     this.body.appendChild(this.display);
 

--- a/packages/UI/controllers/src/switcher.ts
+++ b/packages/UI/controllers/src/switcher.ts
@@ -1,8 +1,13 @@
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
-export class Checkbox extends Controller<boolean> {
+export class Checkbox implements Controller<boolean> {
+  body!: HTMLSpanElement;
+  input!: HTMLInputElement;
+  listeners!: ((e: boolean) => void)[];
+  addListeners!: (...listeners: ((e: boolean) => void)[]) => void;
+  init!: () => void;
   constructor(id: string, label: string) {
-    super("checkbox", id, label);
+    createController<boolean>(this, "checkbox", id, label);
 
     this.input.checked = false;
   }


### PR DESCRIPTION
## Summary
- convert `Controller` and `ControllerView` to interfaces
- add `createController` and `createControllerView` factories
- refactor slider, switcher and color-selector to use factories
- update package exports

## Testing
- `yarn build` *(fails: Could not resolve module in chord-analyze)*
- `yarn test` *(fails: multiple TypeScript errors and missing browser globals)*

------
https://chatgpt.com/codex/tasks/task_e_68423c23d9e08332a78b1a029e0f6eee