### PR TITLE
Refactor switcher controllers

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -25,14 +25,14 @@ import { MusicStructureElements } from "@music-analyzer/piano-roll";
 import { WindowReflectableRegistry, createWindowReflectableRegistry } from "@music-analyzer/view";
 import { BeatInfo } from "@music-analyzer/beat-estimation";
 
-import { DMelodyController } from "@music-analyzer/controllers";
-import { GravityController } from "@music-analyzer/controllers";
+import { DMelodyController, createDMelodyController } from "@music-analyzer/controllers";
+import { GravityController, createGravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
 import { MelodyBeepController } from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
+import { ImplicationDisplayController, createImplicationDisplayController } from "@music-analyzer/controllers";
 
 class Controllers {
   readonly div: HTMLDivElement
@@ -53,11 +53,11 @@ class Controllers {
     this.div.id = "controllers";
     this.div.style = "margin-top:20px";
 
-    this.d_melody = new DMelodyController();
+    this.d_melody = createDMelodyController();
     this.hierarchy = new HierarchyLevelController(layer_count);
     this.time_range = new TimeRangeController(length);
-    this.implication = new ImplicationDisplayController()
-    this.gravity = new GravityController(gravity_visible);
+    this.implication = createImplicationDisplayController()
+    this.gravity = createGravityController(gravity_visible);
     this.melody_beep = new MelodyBeepController();
     this.melody_color = new MelodyColorController();
     this.melody_beep.checkbox.input.checked=true;

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -5,7 +5,14 @@ export { MelodyBeepController } from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";
 export { TimeRangeController } from "./src/slider";
 export { Controller } from "./src/controller";
-export { DMelodyController } from "./src/switcher";
+export {
+  createCheckbox,
+  Checkbox,
+  createDMelodyController,
+  DMelodyController,
+  createGravityController,
+  GravityController,
+  createImplicationDisplayController,
+  ImplicationDisplayController,
+} from "./src/switcher"
 export { Slider } from "./src/slider";
-export { GravityController } from "./src/switcher";
-export { Checkbox } from "./src/switcher";

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,4 +1,4 @@
-import { Checkbox } from "./switcher";
+import { Checkbox, createCheckbox } from "./switcher";
 import { Slider } from "./slider";
 
 class MelodyBeepVolume
@@ -15,23 +15,13 @@ class MelodyBeepVolume
   }
 }
 
-class MelodyBeepSwitcher
-  extends Checkbox {
-  constructor(id: string, label: string) {
-    super(id, label);
-  }
-  update() {
-    const visibility = this.input.checked;
-    this.listeners.forEach(e => e(visibility))
-  };
-};
 
 export class MelodyBeepController {
   readonly view: HTMLDivElement;
-  readonly checkbox: MelodyBeepSwitcher;
+  readonly checkbox: Checkbox;
   readonly volume: MelodyBeepVolume;
   constructor() {
-    const melody_beep_switcher = new MelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
+    const melody_beep_switcher = createCheckbox("melody_beep_switcher", "Beep Melody");
     const melody_beep_volume = new MelodyBeepVolume();
     this.view = document.createElement("div");
     this.view.appendChild(melody_beep_switcher.body,);

--- a/packages/UI/controllers/src/switcher.ts
+++ b/packages/UI/controllers/src/switcher.ts
@@ -1,65 +1,83 @@
 import { Controller } from "./controller";
 
-export class Checkbox extends Controller<boolean> {
-  constructor(id: string, label: string) {
-    super("checkbox", id, label);
+export interface Checkbox {
+  readonly body: HTMLSpanElement
+  readonly input: HTMLInputElement
+  addListeners(...listeners: ((e: boolean) => void)[]): void
+}
 
-    this.input.checked = false;
+export const createCheckbox = (id: string, label: string): Checkbox => {
+  class CheckboxImpl extends Controller<boolean> {
+    constructor() {
+      super("checkbox", id, label)
+      this.input.checked = false
+    }
+    update() {
+      this.listeners.forEach(e => e(this.input.checked))
+    }
   }
-  update() {
-    this.listeners.forEach(e=>e(this.input.checked))
+  return new CheckboxImpl()
+}
+
+export interface DMelodyController {
+  readonly view: HTMLDivElement
+  readonly checkbox: Checkbox
+  addListeners(...listeners: ((e: boolean) => void)[]): void
+}
+
+export const createDMelodyController = (): DMelodyController => {
+  const checkbox = createCheckbox("d_melody_switcher", "detected melody before fix")
+  const view = document.createElement("div")
+  view.id = "d-melody"
+  view.appendChild(checkbox.body)
+  return {
+    view,
+    checkbox,
+    addListeners: (...ls: ((e: boolean) => void)[]) => checkbox.addListeners(...ls),
   }
 }
 
-export class DMelodyController {
-  readonly view: HTMLDivElement;
-  readonly checkbox: Checkbox;
-  constructor() {
-    const d_melody_switcher = new Checkbox("d_melody_switcher", "detected melody before fix");
-    this.view = document.createElement("div");
-    this.view.id = "d-melody";
-    this.view.appendChild(d_melody_switcher.body);
-    this.checkbox = d_melody_switcher;
-  };
-  addListeners(...listeners: ((e:boolean) => void)[]) { this.checkbox.addListeners(...listeners); }
+export interface ImplicationDisplayController {
+  readonly view: HTMLDivElement
+  readonly prospective_checkbox: Checkbox
+  readonly retrospective_checkbox: Checkbox
+  readonly reconstructed_checkbox: Checkbox
 }
 
-export class ImplicationDisplayController {
-  readonly view: HTMLDivElement;
-  readonly prospective_checkbox: Checkbox;
-  readonly retrospective_checkbox: Checkbox;
-  readonly reconstructed_checkbox: Checkbox;
-  constructor() {
-    const prospective_checkbox = new Checkbox("prospective_checkbox", "prospective implication");
-    const retrospective_checkbox = new Checkbox("retrospective_checkbox", "retrospective implication");
-    const reconstructed_checkbox = new Checkbox("reconstructed_checkbox", "reconstructed implication");
-    this.view = document.createElement("div");
-    this.view.id = "prospective-implication";
-    this.view.appendChild(prospective_checkbox.body);
-    this.view.appendChild(retrospective_checkbox.body);
-    this.view.appendChild(reconstructed_checkbox.body);
-    this.prospective_checkbox = prospective_checkbox;
-    this.retrospective_checkbox = retrospective_checkbox;
-    this.reconstructed_checkbox = reconstructed_checkbox;
-  };
+export const createImplicationDisplayController = (): ImplicationDisplayController => {
+  const prospective_checkbox = createCheckbox("prospective_checkbox", "prospective implication")
+  const retrospective_checkbox = createCheckbox("retrospective_checkbox", "retrospective implication")
+  const reconstructed_checkbox = createCheckbox("reconstructed_checkbox", "reconstructed implication")
+  const view = document.createElement("div")
+  view.id = "prospective-implication"
+  view.appendChild(prospective_checkbox.body)
+  view.appendChild(retrospective_checkbox.body)
+  view.appendChild(reconstructed_checkbox.body)
+  return {
+    view,
+    prospective_checkbox,
+    retrospective_checkbox,
+    reconstructed_checkbox,
+  }
 }
 
-export class GravityController {
-  readonly view: HTMLDivElement;
-  readonly chord_checkbox: Checkbox;
-  readonly scale_checkbox: Checkbox;
-  constructor(
-    visible: boolean
-  ) {
-    const chord_gravity_switcher = new Checkbox("chord_gravity_switcher", "Chord Gravity");
-    const scale_gravity_switcher = new Checkbox("scale_gravity_switcher", "Scale Gravity");
+export interface GravityController {
+  readonly view: HTMLDivElement
+  readonly chord_checkbox: Checkbox
+  readonly scale_checkbox: Checkbox
+}
 
-    this.view = document.createElement("div");
-    this.view.id = "gravity-switcher";
-    this.view.style = visible ? "visible" : "hidden";
-    this.view.appendChild(scale_gravity_switcher.body);
-    this.view.appendChild(chord_gravity_switcher.body);
-    this.chord_checkbox = chord_gravity_switcher;
-    this.scale_checkbox = scale_gravity_switcher;
-  };
+export const createGravityController = (visible: boolean): GravityController => {
+  const chord_gravity_switcher = createCheckbox("chord_gravity_switcher", "Chord Gravity")
+  const scale_gravity_switcher = createCheckbox("scale_gravity_switcher", "Scale Gravity")
+  const view = document.createElement("div")
+  view.id = "gravity-switcher"
+  ;(view as any).style = visible ? "visible" : "hidden"
+  view.appendChild(scale_gravity_switcher.body)
+  view.appendChild(chord_gravity_switcher.body)
+  return {
+    view,
+    chord_checkbox: chord_gravity_switcher,
+    scale_checkbox: scale_gravity_switcher,
+  }
 }

--- a/packages/UI/piano-roll/melody-view/index.ts
+++ b/packages/UI/piano-roll/melody-view/index.ts
@@ -1,7 +1,7 @@
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { AudioReflectableRegistry } from "@music-analyzer/view";
 import { WindowReflectableRegistry } from "@music-analyzer/view";
-import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
+import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController, ImplicationDisplayController } from "@music-analyzer/controllers";
 
 import { buildDMelody } from "./src/d-melody-series";
 import { buildIRPlot } from "./src/ir-plot-svg";
@@ -10,7 +10,6 @@ import { buildMelody } from "./src/melody-hierarchy";
 import { buildReduction } from "./src/reduction-hierarchy";
 import { buildGravity } from "./src/gravity-hierarchy";
 import { buildIRGravity } from "./src/ir-gravity-hierarchy";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
 
 export interface RequiredByMelodyElements {
   readonly gravity: GravityController

--- a/packages/UI/piano-roll/melody-view/src/ir-gravity-hierarchy.ts
+++ b/packages/UI/piano-roll/melody-view/src/ir-gravity-hierarchy.ts
@@ -5,7 +5,7 @@ import { Time } from "@music-analyzer/time-and";
 import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
 import { HierarchyLevelController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 import { GetColor } from "@music-analyzer/controllers/src/color-selector";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
+import { ImplicationDisplayController } from "@music-analyzer/controllers";
 import { ITriad } from "@music-analyzer/irm";
 
 interface IRGravityModel {


### PR DESCRIPTION
## Summary
- refactor controller utilities in `switcher.ts` to interfaces and factory functions
- update MelodyBeepController to use new createCheckbox
- adjust controller exports
- update imports and usages across melody view and app index

## Testing
- `yarn build` *(fails: @music-analyzer/chord-analyze#build)*
- `yarn test` *(fails: multiple test suites due to missing modules and AudioContext)*

------
https://chatgpt.com/codex/tasks/task_e_68423c2ab5308332ae96b3c5c18a539c