### PR TITLE
Refactor slider controllers into factory pattern

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -27,10 +27,14 @@ import { BeatInfo } from "@music-analyzer/beat-estimation";
 
 import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
-import { HierarchyLevelController } from "@music-analyzer/controllers";
+import {
+  HierarchyLevelController,
+  TimeRangeController,
+  createHierarchyLevelController,
+  createTimeRangeController,
+} from "@music-analyzer/controllers";
 import { MelodyBeepController } from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
-import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
 import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
 
@@ -54,8 +58,8 @@ class Controllers {
     this.div.style = "margin-top:20px";
 
     this.d_melody = new DMelodyController();
-    this.hierarchy = new HierarchyLevelController(layer_count);
-    this.time_range = new TimeRangeController(length);
+    this.hierarchy = createHierarchyLevelController(layer_count);
+    this.time_range = createTimeRangeController(length);
     this.implication = new ImplicationDisplayController()
     this.gravity = new GravityController(gravity_visible);
     this.melody_beep = new MelodyBeepController();

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -2,10 +2,15 @@ export { SetColor } from "./src/color-selector";
 export { MelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
 export { MelodyBeepController } from "./src/melody-beep-controller";
-export { HierarchyLevelController } from "./src/slider";
-export { TimeRangeController } from "./src/slider";
+export {
+  Slider,
+  createSlider,
+  createHierarchyLevelController,
+  createTimeRangeController,
+  HierarchyLevelController,
+  TimeRangeController,
+} from "./src/slider";
 export { Controller } from "./src/controller";
 export { DMelodyController } from "./src/switcher";
-export { Slider } from "./src/slider";
 export { GravityController } from "./src/switcher";
 export { Checkbox } from "./src/switcher";

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,19 +1,18 @@
 import { Checkbox } from "./switcher";
-import { Slider } from "./slider";
+import { Slider, createSlider } from "./slider";
 
-class MelodyBeepVolume
-  extends Slider<number> {
-  constructor() {
-    super("melody_beep_volume", "", 0, 100, 1);
-  };
-  override updateDisplay() {
-    this.display.textContent = `volume: ${this.input.value}`;
-  }
-  update() {
-    const value = Number(this.input.value);
-    this.listeners.forEach(e => e(value));
-  }
-}
+const createMelodyBeepVolume = (): Slider<number> =>
+  createSlider<number>({
+    id: "melody_beep_volume",
+    label: "",
+    min: 0,
+    max: 100,
+    step: 1,
+    updateDisplay: (input, display) => {
+      display.textContent = `volume: ${input.value}`;
+    },
+    getValue: input => Number(input.value),
+  });
 
 class MelodyBeepSwitcher
   extends Checkbox {
@@ -29,10 +28,10 @@ class MelodyBeepSwitcher
 export class MelodyBeepController {
   readonly view: HTMLDivElement;
   readonly checkbox: MelodyBeepSwitcher;
-  readonly volume: MelodyBeepVolume;
+  readonly volume: Slider<number>;
   constructor() {
     const melody_beep_switcher = new MelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
-    const melody_beep_volume = new MelodyBeepVolume();
+    const melody_beep_volume = createMelodyBeepVolume();
     this.view = document.createElement("div");
     this.view.appendChild(melody_beep_switcher.body,);
     this.view.appendChild(melody_beep_volume.body);


### PR DESCRIPTION
## Summary
- convert `Slider` class and related controllers to interfaces and factories
- update melody beep controller to use new slider factory
- use new controller factories in the analyze app
- expose factory helpers from controllers package

## Testing
- `yarn workspace @music-analyzer/controllers build`
- `yarn build` *(fails: could not resolve chord-progression)*
- `yarn test` *(fails: various type errors and missing browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68423c2e5ac483329c1a036324f447b0