### PR TITLE
Refactor melody beep controller

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -28,7 +28,7 @@ import { BeatInfo } from "@music-analyzer/beat-estimation";
 import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
-import { MelodyBeepController } from "@music-analyzer/controllers";
+import { type MelodyBeepController, createMelodyBeepController } from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
@@ -58,7 +58,7 @@ class Controllers {
     this.time_range = new TimeRangeController(length);
     this.implication = new ImplicationDisplayController()
     this.gravity = new GravityController(gravity_visible);
-    this.melody_beep = new MelodyBeepController();
+    this.melody_beep = createMelodyBeepController();
     this.melody_color = new MelodyColorController();
     this.melody_beep.checkbox.input.checked=true;
     this.implication.prospective_checkbox.input.checked = false;

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,7 +1,8 @@
 export { SetColor } from "./src/color-selector";
 export { MelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
-export { MelodyBeepController } from "./src/melody-beep-controller";
+export type { MelodyBeepVolume, MelodyBeepSwitcher, MelodyBeepController } from "./src/melody-beep-controller";
+export { createMelodyBeepVolume, createMelodyBeepSwitcher, createMelodyBeepController } from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";
 export { TimeRangeController } from "./src/slider";
 export { Controller } from "./src/controller";

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,43 +1,55 @@
 import { Checkbox } from "./switcher";
 import { Slider } from "./slider";
 
-class MelodyBeepVolume
-  extends Slider<number> {
-  constructor() {
-    super("melody_beep_volume", "", 0, 100, 1);
-  };
-  override updateDisplay() {
-    this.display.textContent = `volume: ${this.input.value}`;
+export interface MelodyBeepVolume extends Slider<number> {}
+
+export function createMelodyBeepVolume(): MelodyBeepVolume {
+  class Impl extends Slider<number> {
+    constructor() {
+      super("melody_beep_volume", "", 0, 100, 1);
+    }
+    override updateDisplay() {
+      this.display.textContent = `volume: ${this.input.value}`;
+    }
+    update() {
+      const value = Number(this.input.value);
+      this.listeners.forEach(e => e(value));
+    }
   }
-  update() {
-    const value = Number(this.input.value);
-    this.listeners.forEach(e => e(value));
-  }
+  return new Impl();
 }
 
-class MelodyBeepSwitcher
-  extends Checkbox {
-  constructor(id: string, label: string) {
-    super(id, label);
-  }
-  update() {
-    const visibility = this.input.checked;
-    this.listeners.forEach(e => e(visibility))
-  };
-};
+export interface MelodyBeepSwitcher extends Checkbox {}
 
-export class MelodyBeepController {
+export function createMelodyBeepSwitcher(id: string, label: string): MelodyBeepSwitcher {
+  class Impl extends Checkbox {
+    constructor(id: string, label: string) {
+      super(id, label);
+    }
+    update() {
+      const visibility = this.input.checked;
+      this.listeners.forEach(e => e(visibility));
+    }
+  }
+  return new Impl(id, label);
+}
+
+export interface MelodyBeepController {
   readonly view: HTMLDivElement;
   readonly checkbox: MelodyBeepSwitcher;
   readonly volume: MelodyBeepVolume;
-  constructor() {
-    const melody_beep_switcher = new MelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
-    const melody_beep_volume = new MelodyBeepVolume();
-    this.view = document.createElement("div");
-    this.view.appendChild(melody_beep_switcher.body,);
-    this.view.appendChild(melody_beep_volume.body);
-    this.view.id = "melody-beep-controllers";
-    this.checkbox = melody_beep_switcher;
-    this.volume = melody_beep_volume;
+}
+
+export function createMelodyBeepController(): MelodyBeepController {
+  const melody_beep_switcher = createMelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
+  const melody_beep_volume = createMelodyBeepVolume();
+  const view = document.createElement("div");
+  view.appendChild(melody_beep_switcher.body);
+  view.appendChild(melody_beep_volume.body);
+  view.id = "melody-beep-controllers";
+  return {
+    view,
+    checkbox: melody_beep_switcher,
+    volume: melody_beep_volume,
   };
 }

--- a/packages/UI/piano-roll/melody-view/index.ts
+++ b/packages/UI/piano-roll/melody-view/index.ts
@@ -1,7 +1,7 @@
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { AudioReflectableRegistry } from "@music-analyzer/view";
 import { WindowReflectableRegistry } from "@music-analyzer/view";
-import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
+import { DMelodyController, GravityController, HierarchyLevelController, type MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 
 import { buildDMelody } from "./src/d-melody-series";
 import { buildIRPlot } from "./src/ir-plot-svg";

--- a/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
+++ b/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
@@ -5,7 +5,7 @@ import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze"
 import { play } from "@music-analyzer/synth";
 import { black_key_height, NowAt, PianoRollConverter } from "@music-analyzer/view-parameters";
 import { reservation_range } from "@music-analyzer/view-parameters";
-import { HierarchyLevelController, MelodyBeepController, MelodyColorController, SetColor, TimeRangeController } from "@music-analyzer/controllers";
+import { HierarchyLevelController, type MelodyBeepController, MelodyColorController, SetColor, TimeRangeController } from "@music-analyzer/controllers";
 import { Time, createTime } from "@music-analyzer/time-and";
 import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
 

--- a/packages/UI/piano-roll/melody-view/src/reduction-tree.ts
+++ b/packages/UI/piano-roll/melody-view/src/reduction-tree.ts
@@ -1,5 +1,5 @@
 import { PianoRollConverter } from "@music-analyzer/view-parameters";
-import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
+import { DMelodyController, GravityController, HierarchyLevelController, type MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 import { AudioReflectableRegistry, WindowReflectableRegistry } from "@music-analyzer/view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 


### PR DESCRIPTION
## Summary
- switch melody beep controller to interface + factory design
- update exports and usages to match factory API

## Testing
- `yarn build` *(fails: Could not resolve './key-estimation/chord-progression')*
- `yarn test` *(fails: jest tests fail to run)*

------
https://chatgpt.com/codex/tasks/task_e_68423c32e6748332acd7a2bcdd475a3a