### PR TITLE
Refactor color selector into interfaces

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -29,7 +29,7 @@ import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
 import { MelodyBeepController } from "@music-analyzer/controllers";
-import { MelodyColorController } from "@music-analyzer/controllers";
+import { MelodyColorController, createMelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
 import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
@@ -59,7 +59,7 @@ class Controllers {
     this.implication = new ImplicationDisplayController()
     this.gravity = new GravityController(gravity_visible);
     this.melody_beep = new MelodyBeepController();
-    this.melody_color = new MelodyColorController();
+    this.melody_color = createMelodyColorController();
     this.melody_beep.checkbox.input.checked=true;
     this.implication.prospective_checkbox.input.checked = false;
     this.implication.retrospective_checkbox.input.checked = true;

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,5 +1,5 @@
 export { SetColor } from "./src/color-selector";
-export { MelodyColorController } from "./src/color-selector";
+export { MelodyColorController, createMelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
 export { MelodyBeepController } from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";


### PR DESCRIPTION
## Summary
- refactor color selector classes to interfaces
- provide `createMelodyColorController` factory
- update controller exports and usage

## Testing
- `yarn build` *(fails: Could not resolve "./key-estimation/chord-progression" for chord analyze build)*
- `yarn test` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68423c3940e88332888339d2d5c26dbe