### PR TITLE
Refactor slider controllers to use factories

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -27,10 +27,10 @@ import { BeatInfo } from "@music-analyzer/beat-estimation";
 
 import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
-import { HierarchyLevelController } from "@music-analyzer/controllers";
+import { HierarchyLevelController, createHierarchyLevelController } from "@music-analyzer/controllers";
 import { MelodyBeepController } from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
-import { TimeRangeController } from "@music-analyzer/controllers";
+import { TimeRangeController, createTimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
 import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
 
@@ -54,8 +54,8 @@ class Controllers {
     this.div.style = "margin-top:20px";
 
     this.d_melody = new DMelodyController();
-    this.hierarchy = new HierarchyLevelController(layer_count);
-    this.time_range = new TimeRangeController(length);
+    this.hierarchy = createHierarchyLevelController(layer_count);
+    this.time_range = createTimeRangeController(length);
     this.implication = new ImplicationDisplayController()
     this.gravity = new GravityController(gravity_visible);
     this.melody_beep = new MelodyBeepController();

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -2,10 +2,19 @@ export { SetColor } from "./src/color-selector";
 export { MelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
 export { MelodyBeepController } from "./src/melody-beep-controller";
-export { HierarchyLevelController } from "./src/slider";
-export { TimeRangeController } from "./src/slider";
+export {
+  Slider,
+  createSlider,
+  HierarchyLevel,
+  createHierarchyLevel,
+  HierarchyLevelController,
+  createHierarchyLevelController,
+  TimeRangeSlider,
+  createTimeRangeSlider,
+  TimeRangeController,
+  createTimeRangeController,
+} from "./src/slider";
 export { Controller } from "./src/controller";
 export { DMelodyController } from "./src/switcher";
-export { Slider } from "./src/slider";
 export { GravityController } from "./src/switcher";
 export { Checkbox } from "./src/switcher";

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,19 +1,27 @@
 import { Checkbox } from "./switcher";
-import { Slider } from "./slider";
+import { Slider, createSlider } from "./slider";
 
-class MelodyBeepVolume
-  extends Slider<number> {
-  constructor() {
-    super("melody_beep_volume", "", 0, 100, 1);
+export interface MelodyBeepVolume extends Slider<number> {}
+
+const createMelodyBeepVolume = (): MelodyBeepVolume => {
+  const updateDisplay = (s: Slider<number>) => {
+    s.display.textContent = `volume: ${s.input.value}`;
   };
-  override updateDisplay() {
-    this.display.textContent = `volume: ${this.input.value}`;
-  }
-  update() {
-    const value = Number(this.input.value);
-    this.listeners.forEach(e => e(value));
-  }
-}
+  const updateFn = (s: Slider<number>, ls: ((e: number) => void)[]) => {
+    const value = Number(s.input.value);
+    ls.forEach(e => e(value));
+  };
+  return createSlider<number>(
+    "melody_beep_volume",
+    "",
+    0,
+    100,
+    1,
+    undefined,
+    updateFn,
+    updateDisplay,
+  );
+};
 
 class MelodyBeepSwitcher
   extends Checkbox {
@@ -32,7 +40,7 @@ export class MelodyBeepController {
   readonly volume: MelodyBeepVolume;
   constructor() {
     const melody_beep_switcher = new MelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
-    const melody_beep_volume = new MelodyBeepVolume();
+    const melody_beep_volume = createMelodyBeepVolume();
     this.view = document.createElement("div");
     this.view.appendChild(melody_beep_switcher.body,);
     this.view.appendChild(melody_beep_volume.body);

--- a/packages/UI/controllers/src/slider.ts
+++ b/packages/UI/controllers/src/slider.ts
@@ -1,97 +1,162 @@
 import { PianoRollRatio } from "@music-analyzer/view-parameters";
-import { Controller } from "./controller";
+import { ControllerView } from "./controller";
 
-export abstract class Slider<T> extends Controller<T> {
+export interface Slider<T> {
+  readonly body: HTMLSpanElement;
+  readonly input: HTMLInputElement;
   readonly display: HTMLSpanElement;
-  constructor(id: string, label: string, min: number, max: number, step: number, value?: number) {
-    super ("range", id, label);
-    this.display = document.createElement("span");
-    this.body.appendChild(this.display);
-
-    this.input.min = String(min);
-    this.input.max = String(max);
-    this.input.step = String(step);
-    value && (this.input.value = String(value));
-
-    this.updateDisplay();
-    this.input.addEventListener("input", this.updateDisplay.bind(this));
-  }
-  abstract updateDisplay(): void;
+  addListeners(...listeners: ((e: T) => void)[]): void;
+  update(): void;
+  updateDisplay(): void;
 }
 
-class HierarchyLevel
-  extends Slider<number> {
-  constructor() {
-    super("hierarchy_level_slider", "Melody Hierarchy Level", 0, 1, 1);
+export const createSlider = <T>(
+  id: string,
+  label: string,
+  min: number,
+  max: number,
+  step: number,
+  value: number | undefined,
+  updateFn: (slider: Slider<T>, listeners: ((e: T) => void)[]) => void,
+  updateDisplayFn: (slider: Slider<T>) => void,
+): Slider<T> => {
+  const view = new ControllerView("range", id, label);
+  const display = document.createElement("span");
+  view.body.appendChild(display);
+
+  view.input.min = String(min);
+  view.input.max = String(max);
+  view.input.step = String(step);
+  value !== undefined && (view.input.value = String(value));
+
+  const listeners: ((e: T) => void)[] = [];
+
+  const slider: Slider<T> = {
+    body: view.body,
+    input: view.input,
+    display,
+    addListeners: () => undefined,
+    update: () => undefined,
+    updateDisplay: () => undefined,
   };
-  override updateDisplay() {
-    this.display.textContent = `layer: ${this.input.value}`;
-  }
-  setHierarchyLevelSliderValues = (max: number) => {
-    this.input.max = String(max);
-    this.input.value = String(max);
-    this.updateDisplay();
+
+  slider.addListeners = (...ls: ((e: T) => void)[]) => {
+    listeners.push(...ls);
+    slider.update();
   };
-  update() {
-    const value = Number(this.input.value);
-    this.listeners.forEach(e => e(value));
-  }
+  slider.update = () => updateFn(slider, listeners);
+  slider.updateDisplay = () => updateDisplayFn(slider);
+
+  view.input.addEventListener("input", () => {
+    slider.updateDisplay();
+    slider.update();
+  });
+
+  slider.updateDisplay();
+  return slider;
 };
 
-export class HierarchyLevelController {
+export interface HierarchyLevel extends Slider<number> {
+  setHierarchyLevelSliderValues(max: number): void;
+}
+
+export const createHierarchyLevel = (): HierarchyLevel => {
+  const updateDisplay = (s: Slider<number>) => {
+    s.display.textContent = `layer: ${s.input.value}`;
+  };
+  const updateFn = (s: Slider<number>, ls: ((e: number) => void)[]) => {
+    const value = Number(s.input.value);
+    ls.forEach(e => e(value));
+  };
+  const slider = createSlider<number>(
+    "hierarchy_level_slider",
+    "Melody Hierarchy Level",
+    0,
+    1,
+    1,
+    undefined,
+    updateFn,
+    updateDisplay,
+  );
+  const setHierarchyLevelSliderValues = (max: number) => {
+    slider.input.max = String(max);
+    slider.input.value = String(max);
+    slider.updateDisplay();
+  };
+  return { ...slider, setHierarchyLevelSliderValues };
+};
+
+export interface HierarchyLevelController {
   readonly view: HTMLDivElement;
   readonly slider: HierarchyLevel;
-  constructor(layer_count: number) {
-    const hierarchy_level = new HierarchyLevel();
-    this.view = document.createElement("div");
-    this.view.id = "hierarchy-level";
-    this.view.appendChild(hierarchy_level.body);
-    this.slider = hierarchy_level;
-    this.slider.setHierarchyLevelSliderValues(layer_count)
-  }
-  addListeners(...listeners: ((e:number) => void)[]) { this.slider.addListeners(...listeners); }
+  addListeners(...listeners: ((e: number) => void)[]): void;
 }
 
-export class TimeRangeController {
-  readonly view: HTMLDivElement;
-  readonly slider: TimeRangeSlider;
-  constructor(length: number) {
-    const time_range_slider = new TimeRangeSlider();
-    this.view = document.createElement("div");
-    this.view.id = "time-length";
-    this.view.appendChild(time_range_slider.body);
-    this.slider = time_range_slider;
-
-    if (length > 30) {
-      const window = 30;  // 秒のつもりだが, 秒になってない感じがする
-      const ratio = window / length;
-      const max = this.slider.input.max;
-      const value = max + Math.log2(ratio);
-      this.slider.input.value = String(value);
-      this.slider.updateDisplay();
-    }
-  }
-  addListeners(...listeners: (() => void)[]) { this.slider.addListeners(...listeners); }
-}
-class TimeRangeSlider
-  extends Slider<number> {
-  constructor() {
-    super("time_range_slider", "Time Range", 1, 10, 0.1, 10);
+export const createHierarchyLevelController = (layer_count: number): HierarchyLevelController => {
+  const slider = createHierarchyLevel();
+  const view = document.createElement("div");
+  view.id = "hierarchy-level";
+  view.appendChild(slider.body);
+  slider.setHierarchyLevelSliderValues(layer_count);
+  return {
+    view,
+    slider,
+    addListeners: (...ls: ((e: number) => void)[]) => slider.addListeners(...ls),
   };
-  override updateDisplay() {
-    [Number(this.input.value)]
-      .map(e => e - Number(this.input.max))
-      .map(e => Math.pow(2, e))
-      .map(e => e * 100)
-      .map(e => Math.floor(e))
-      .map(e => `${e} %`)
-      .map(e => this.display.textContent = e)
-  }
-  update() {
-    const value = Number(this.input.value);
-    const max = Number(this.input.max);
+};
+
+export interface TimeRangeSlider extends Slider<number> {}
+
+export const createTimeRangeSlider = (): TimeRangeSlider => {
+  const updateDisplay = (s: Slider<number>) => {
+    const value = Number(s.input.value);
+    const max = Number(s.input.max);
+    const percent = Math.floor(Math.pow(2, value - max) * 100);
+    s.display.textContent = `${percent} %`;
+  };
+  const updateFn = (s: Slider<number>, ls: ((e: number) => void)[]) => {
+    const value = Number(s.input.value);
+    const max = Number(s.input.max);
     const ratio = Math.pow(2, value - max);
     PianoRollRatio.set(ratio);
-    this.listeners.forEach(e => e(ratio));
-  }
+    ls.forEach(e => e(ratio));
+  };
+  return createSlider<number>(
+    "time_range_slider",
+    "Time Range",
+    1,
+    10,
+    0.1,
+    10,
+    updateFn,
+    updateDisplay,
+  );
+};
+
+export interface TimeRangeController {
+  readonly view: HTMLDivElement;
+  readonly slider: TimeRangeSlider;
+  addListeners(...listeners: (() => void)[]): void;
 }
+
+export const createTimeRangeController = (length: number): TimeRangeController => {
+  const slider = createTimeRangeSlider();
+  const view = document.createElement("div");
+  view.id = "time-length";
+  view.appendChild(slider.body);
+
+  if (length > 30) {
+    const window = 30;  // 秒のつもりだが, 秒になってない感じがする
+    const ratio = window / length;
+    const max = Number(slider.input.max);
+    const value = max + Math.log2(ratio);
+    slider.input.value = String(value);
+    slider.updateDisplay();
+  }
+
+  return {
+    view,
+    slider,
+    addListeners: (...ls: (() => void)[]) => slider.addListeners(...ls),
+  };
+};


### PR DESCRIPTION
## Summary
- refactor slider abstractions into interfaces with factory functions
- adapt melody beep controller to use new slider factory
- expose new factories from `@music-analyzer/controllers`
- update HTML analyzer to create controllers via factories

## Testing
- `yarn workspace @music-analyzer/controllers build`
- `yarn test` *(fails: ChordProgression type errors, RomanChord usage, missing DOM APIs, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68423c8cea3c83328694a42189ded691