### PR TITLE
Refactor melody beep controller to factory functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ and roman–numeral data and outputs analysis results.
 
 These commands operate from the repository root and leverage the Yarn workspace
 configuration.
+**Note for new contributors**: Run `yarn install` (or `npm install`) before using `tsc` or running the tests. Running `yarn` creates a `yarn.lock` file for repeatable installs.
 
 ### Creating utility instances
 

--- a/dependency-graph.svg
+++ b/dependency-graph.svg
@@ -2913,22 +2913,6 @@
 <path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M914.78,-1697.11C1012.93,-1697.54 1352.5,-1699 1352.5,-1699 1352.5,-1699 1376.99,-1701.63 1400.83,-1704.2"/>
 <polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1406.64,-1706.93 1400.9,-1704.2 1407.09,-1702.76 1406.64,-1706.93"/>
 </g>
-<<<<<<< HEAD
-<!-- packages/UI/synth/src/create&#45;oscilllator.ts -->
-<g id="node108" class="node">
-<title>packages/UI/synth/src/create&#45;oscilllator.ts</title>
-<g id="a_node108"><a xlink:href="packages/UI/synth/src/create-oscilllator.ts" xlink:title="create&#45;oscilllator.ts">
-<path fill="#ddfeff" stroke="black" d="M1491,-1748C1491,-1748 1402,-1748 1402,-1748 1399,-1748 1396,-1745 1396,-1742 1396,-1742 1396,-1736 1396,-1736 1396,-1733 1399,-1730 1402,-1730 1402,-1730 1491,-1730 1491,-1730 1494,-1730 1497,-1733 1497,-1736 1497,-1736 1497,-1742 1497,-1742 1497,-1745 1494,-1748 1491,-1748"/>
-<text text-anchor="start" x="1404" y="-1736.8" font-family="Helvetica,sans-Serif" font-size="9.00">create&#45;oscilllator.ts</text>
-</a>
-</g>
-</g>
-<!-- packages/UI/synth/index.ts&#45;&gt;packages/UI/synth/src/create&#45;oscilllator.ts -->
-<g id="edge195" class="edge">
-<title>packages/UI/synth/index.ts&#45;&gt;packages/UI/synth/src/create&#45;oscilllator.ts</title>
-<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M914.76,-1697.94C989.24,-1700.6 1196.5,-1708 1196.5,-1708 1196.5,-1708 1352.5,-1717 1352.5,-1717 1352.5,-1717 1360.5,-1724 1360.5,-1724 1360.5,-1724 1373.64,-1726.32 1389.58,-1729.13"/>
-<polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1395.2,-1732.26 1389.65,-1729.14 1395.93,-1728.12 1395.2,-1732.26"/>
-=======
 <!-- packages/UI/synth/src/create&#45;oscillator.ts -->
 <g id="node110" class="node">
 <title>packages/UI/synth/src/create&#45;oscillator.ts</title>
@@ -2943,7 +2927,6 @@
 <title>packages/UI/synth/index.ts&#45;&gt;packages/UI/synth/src/create&#45;oscillator.ts</title>
 <path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M914.76,-1836.94C989.24,-1839.6 1196.5,-1847 1196.5,-1847 1196.5,-1847 1361.5,-1856 1361.5,-1856 1361.5,-1856 1374.5,-1863 1374.5,-1863 1374.5,-1863 1384.84,-1865.08 1397.82,-1867.7"/>
 <polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1403.53,-1870.99 1398.06,-1867.74 1404.36,-1866.87 1403.53,-1870.99"/>
->>>>>>> 0dabeaf0e51df66518b5149c4d283cda84591075
 </g>
 <!-- packages/UI/synth/src/play.ts -->
 <g id="node109" class="node">
@@ -2981,19 +2964,11 @@
 <path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M1308.27,-1728.3C1333.13,-1724.81 1370.95,-1719.49 1400.6,-1715.32"/>
 <polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1401.14,-1717.36 1406.79,-1714.44 1400.56,-1713.2 1401.14,-1717.36"/>
 </g>
-<<<<<<< HEAD
-<!-- packages/UI/synth/src/play.ts&#45;&gt;packages/UI/synth/src/create&#45;oscilllator.ts -->
-<g id="edge200" class="edge">
-<title>packages/UI/synth/src/play.ts&#45;&gt;packages/UI/synth/src/create&#45;oscilllator.ts</title>
-<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M1308.27,-1733.12C1330.17,-1734.06 1362.14,-1735.43 1389.71,-1736.61"/>
-<polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1389.8,-1738.72 1395.88,-1736.88 1389.98,-1734.52 1389.8,-1738.72"/>
-=======
 <!-- packages/UI/synth/src/play.ts&#45;&gt;packages/UI/synth/src/create&#45;oscillator.ts -->
 <g id="edge209" class="edge">
 <title>packages/UI/synth/src/play.ts&#45;&gt;packages/UI/synth/src/create&#45;oscillator.ts</title>
 <path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" d="M1314.23,-1872.14C1335.6,-1873.07 1366.52,-1874.41 1393.36,-1875.58"/>
 <polygon fill="#000000" fill-opacity="0.200000" stroke="#000000" stroke-width="2" stroke-opacity="0.200000" points="1393.29,-1877.68 1399.38,-1875.84 1393.47,-1873.48 1393.29,-1877.68"/>
->>>>>>> 0dabeaf0e51df66518b5149c4d283cda84591075
 </g>
 <!-- packages/UI/synth/src/play&#45;note.ts&#45;&gt;packages/UI/synth/src/play.ts -->
 <g id="edge198" class="edge">

--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -1,7 +1,7 @@
 import { setCurrentTimeRatio, setPianoRollParameters } from "@music-analyzer/view-parameters";
 import { song_list } from "@music-analyzer/gttm";
 import { createAnalyzedDataContainer } from "@music-analyzer/analyzed-data-container";
-import { AudioViewer } from "@music-analyzer/spectrogram";
+import { createAudioViewer, AudioViewer } from "@music-analyzer/spectrogram";
 import { PianoRoll } from "@music-analyzer/piano-roll";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { PianoRollWidth } from "@music-analyzer/view-parameters";
@@ -25,17 +25,14 @@ import { MusicStructureElements } from "@music-analyzer/piano-roll";
 import { WindowReflectableRegistry, createWindowReflectableRegistry } from "@music-analyzer/view";
 import { BeatInfo } from "@music-analyzer/beat-estimation";
 
-import { DMelodyController } from "@music-analyzer/controllers";
-import { GravityController } from "@music-analyzer/controllers";
+import { DMelodyController, createDMelodyController } from "@music-analyzer/controllers";
+import { GravityController, createGravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
-import {
-  MelodyBeepController,
-  createMelodyBeepController,
-} from "@music-analyzer/controllers";
+import { type MelodyBeepController, createMelodyBeepController } from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
+import { ImplicationDisplayController, createImplicationDisplayController } from "@music-analyzer/controllers";
 
 class Controllers {
   readonly div: HTMLDivElement
@@ -56,7 +53,7 @@ class Controllers {
     this.div.id = "controllers";
     this.div.style = "margin-top:20px";
 
-    this.d_melody = new DMelodyController();
+    this.d_melody = createDMelodyController();
     this.hierarchy = new HierarchyLevelController(layer_count);
     this.time_range = new TimeRangeController(length);
     this.implication = new ImplicationDisplayController()
@@ -328,7 +325,7 @@ const setupUI = (
   piano_roll_place: HTMLDivElement,
   manager: ApplicationManager,
 ) => {
-  const audio_viewer = new AudioViewer(audio_player, manager.audio_time_mediator);
+  const audio_viewer = createAudioViewer(audio_player, manager.audio_time_mediator);
   const piano_roll_view = new PianoRoll(manager.analyzed, manager.window_size_mediator, !manager.FULL_VIEW)
   asParent(piano_roll_place)
     .appendChildren(

--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -28,7 +28,10 @@ import { BeatInfo } from "@music-analyzer/beat-estimation";
 import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
-import { MelodyBeepController } from "@music-analyzer/controllers";
+import {
+  MelodyBeepController,
+  createMelodyBeepController,
+} from "@music-analyzer/controllers";
 import { MelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
@@ -58,7 +61,7 @@ class Controllers {
     this.time_range = new TimeRangeController(length);
     this.implication = new ImplicationDisplayController()
     this.gravity = new GravityController(gravity_visible);
-    this.melody_beep = new MelodyBeepController();
+    this.melody_beep = createMelodyBeepController();
     this.melody_color = new MelodyColorController();
     this.melody_beep.checkbox.input.checked=true;
     this.implication.prospective_checkbox.input.checked = false;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/jsdom": "^21.1.7",
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.26.0",
     "depcheck": "^1.4.7",
@@ -37,6 +38,7 @@
     "eslint": "^9.21.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
+    "jsdom": "^26.1.0",
     "madge": "^8.0.0",
     "ts-jest": "^29.2.6",
     "tsup": "^8.4.0",

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,7 +1,14 @@
 export { SetColor } from "./src/color-selector";
 export { MelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
-export { MelodyBeepController } from "./src/melody-beep-controller";
+export {
+  MelodyBeepController,
+  MelodyBeepSwitcher,
+  MelodyBeepVolume,
+  createMelodyBeepController,
+  createMelodyBeepSwitcher,
+  createMelodyBeepVolume,
+} from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";
 export { TimeRangeController } from "./src/slider";
 export { Controller } from "./src/controller";

--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,18 +1,19 @@
 export { SetColor } from "./src/color-selector";
-export { MelodyColorController } from "./src/color-selector";
+export { MelodyColorController, createMelodyColorController } from "./src/color-selector";
 export { ControllerView } from "./src/controller";
-export {
-  MelodyBeepController,
-  MelodyBeepSwitcher,
-  MelodyBeepVolume,
-  createMelodyBeepController,
-  createMelodyBeepSwitcher,
-  createMelodyBeepVolume,
-} from "./src/melody-beep-controller";
+export type { MelodyBeepVolume, MelodyBeepSwitcher, MelodyBeepController } from "./src/melody-beep-controller";
+export { createMelodyBeepVolume, createMelodyBeepSwitcher, createMelodyBeepController } from "./src/melody-beep-controller";
 export { HierarchyLevelController } from "./src/slider";
 export { TimeRangeController } from "./src/slider";
 export { Controller } from "./src/controller";
-export { DMelodyController } from "./src/switcher";
+export {
+  createCheckbox,
+  Checkbox,
+  createDMelodyController,
+  DMelodyController,
+  createGravityController,
+  GravityController,
+  createImplicationDisplayController,
+  ImplicationDisplayController,
+} from "./src/switcher"
 export { Slider } from "./src/slider";
-export { GravityController } from "./src/switcher";
-export { Checkbox } from "./src/switcher";

--- a/packages/UI/controllers/src/color-selector.ts
+++ b/packages/UI/controllers/src/color-selector.ts
@@ -5,50 +5,68 @@ import { get_color_on_digital_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_intervallic_angle } from "@music-analyzer/irm";
 import { get_color_on_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_registral_scale } from "@music-analyzer/irm";
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
 
 export type GetColor = (e: ITriad) => string;
 export type SetColor = (getColor: GetColor) => void;
 
-abstract class ColorSelector<T> extends Controller<T> {
-  constructor(
-    readonly id: string,
-    text: string
-  ) {
-    super("radio", id, text);
-  };
+export interface ColorSelector<T> {
+  readonly body: HTMLSpanElement;
+  readonly input: HTMLInputElement;
+  addListeners(...listeners: ((e: T) => void)[]): void;
 }
 
-class IRM_ColorSelector
-  extends ColorSelector<GetColor> {
-  getColor: GetColor;
+export interface IRM_ColorSelector extends ColorSelector<GetColor> {
+  readonly getColor: GetColor;
+}
+
+export interface MelodyColorSelector {
+  readonly body: HTMLDivElement;
+  addListeners(...listeners: ((color: GetColor) => void)[]): void;
+}
+
+export interface MelodyColorController {
+  readonly view: HTMLDivElement;
+  readonly selector: MelodyColorSelector;
+  addListeners(...listeners: ((color: GetColor) => void)[]): void;
+}
+
+class ColorSelectorImpl<T> extends Controller<T> implements ColorSelector<T> {
+  constructor(id: string, text: string) {
+    super("radio", id, text);
+  }
+  update() { /* noop */ }
+}
+
+class IRM_ColorSelectorImpl
+  extends ColorSelectorImpl<GetColor>
+  implements IRM_ColorSelector {
   constructor(
     id: string,
     text: string,
-    getColor: GetColor,
+    readonly getColor: GetColor,
   ) {
     super(id, text);
-    this.getColor = getColor
   }
-  update() {
+  override update() {
     this.listeners.forEach(setColor => setColor(triad => this.getColor(triad)));
   }
 }
 
-class MelodyColorSelector {
-  readonly body: HTMLSpanElement;
-  readonly children: IRM_ColorSelector[];
-  readonly default: IRM_ColorSelector;
+class MelodyColorSelectorImpl implements MelodyColorSelector {
+  readonly body: HTMLDivElement;
+  readonly children: IRM_ColorSelectorImpl[];
+  readonly default: IRM_ColorSelectorImpl;
   constructor() {
     this.children = [
-      new IRM_ColorSelector("Narmour_concept", "Narmour concept color", get_color_of_Narmour_concept),
-      new IRM_ColorSelector("implication_realization", "implication realization", get_color_of_implication_realization),
-      new IRM_ColorSelector("digital_parametric_scale", "digital parametric scale color", get_color_on_digital_parametric_scale),
-      new IRM_ColorSelector("digital_intervallic_scale", "digital intervallic scale color", get_color_on_digital_intervallic_scale),
-      new IRM_ColorSelector("registral_scale", "registral scale color", get_color_on_registral_scale),
-      new IRM_ColorSelector("intervallic_angle", "intervallic angle color", get_color_on_intervallic_angle),
-      new IRM_ColorSelector("analog_parametric_scale", "analog parametric scale color", get_color_on_parametric_scale),
+      new IRM_ColorSelectorImpl("Narmour_concept", "Narmour concept color", get_color_of_Narmour_concept),
+      new IRM_ColorSelectorImpl("implication_realization", "implication realization", get_color_of_implication_realization),
+      new IRM_ColorSelectorImpl("digital_parametric_scale", "digital parametric scale color", get_color_on_digital_parametric_scale),
+      new IRM_ColorSelectorImpl("digital_intervallic_scale", "digital intervallic scale color", get_color_on_digital_intervallic_scale),
+      new IRM_ColorSelectorImpl("registral_scale", "registral scale color", get_color_on_registral_scale),
+      new IRM_ColorSelectorImpl("intervallic_angle", "intervallic angle color", get_color_on_intervallic_angle),
+      new IRM_ColorSelectorImpl("analog_parametric_scale", "analog parametric scale color", get_color_on_parametric_scale),
     ];
     this.children.forEach(e => { e.input.name = "melody-color-selector"; });
 
@@ -61,22 +79,26 @@ class MelodyColorSelector {
     this.default.update();
   }
   addListeners(...listeners: ((color: GetColor) => void)[]) {
-    this.children.forEach(e => e.addListeners(...listeners))
-    this.default.update()
+    this.children.forEach(e => e.addListeners(...listeners));
+    this.default.update();
   }
 }
 
-export class MelodyColorController {
+class MelodyColorControllerImpl implements MelodyColorController {
   readonly view: HTMLDivElement;
-  readonly selector: MelodyColorSelector;
+  readonly selector: MelodyColorSelectorImpl;
   constructor() {
-    this.selector = new MelodyColorSelector();
+    this.selector = new MelodyColorSelectorImpl();
     this.view = document.createElement("div");
     this.view.id = "melody-color-selector";
     this.view.style.display = "inline";
     this.view.appendChild(this.selector.body);
   }
   addListeners(...listeners: ((color: GetColor) => void)[]) {
-    this.selector.addListeners(...listeners)
+    this.selector.addListeners(...listeners);
   }
 }
+
+export const createMelodyColorController = (): MelodyColorController =>
+  new MelodyColorControllerImpl();
+

--- a/packages/UI/controllers/src/controller.ts
+++ b/packages/UI/controllers/src/controller.ts
@@ -1,53 +1,84 @@
-type HTMLInputElementType = "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file" | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset" | "search" | "submit" | "tel" | "text" | "time" | "url" | "week";
-
-export abstract class Controller<T> {
-  readonly body: HTMLSpanElement;
-  readonly input: HTMLInputElement;
-  constructor(
-    type: HTMLInputElementType,
-    id: string,
-    label: string,
-  ) {
-    const e = new ControllerView(type, id, label);
-    this.body = e.body;
-    this.input = e.input
-    this.init()
-  }
-  protected readonly listeners: ((e:T) => void)[] = []
-  addListeners(...listeners: ((e:T) => void)[]) {
-    this.listeners.push(...listeners);
-    this.update();
-  }
-  abstract update(): void;
-  init() {
-    this.input.addEventListener("input", this.update.bind(this));
-    this.update();
-  };
+type HTMLInputElementType =
+  | "button"
+  | "checkbox"
+  | "color"
+  | "date"
+  | "datetime-local"
+  | "email"
+  | "file"
+  | "hidden"
+  | "image"
+  | "month"
+  | "number"
+  | "password"
+  | "radio"
+  | "range"
+  | "reset"
+  | "search"
+  | "submit"
+  | "tel"
+  | "text"
+  | "time"
+  | "url"
+  | "week";
+export interface Controller<T> {
+  body: HTMLSpanElement;
+  input: HTMLInputElement;
+  listeners: ((e: T) => void)[];
+  addListeners: (...listeners: ((e: T) => void)[]) => void;
+  update: () => void;
+  init: () => void;
 }
 
-export class ControllerView {
-  readonly body: HTMLSpanElement;
-  readonly input: HTMLInputElement;
-  readonly label: HTMLLabelElement;
+export interface ControllerView {
+  body: HTMLSpanElement;
+  input: HTMLInputElement;
+  label: HTMLLabelElement;
+}
 
-  constructor(
-    type: HTMLInputElementType,
-    id: string,
-    label: string,
-  ) {
-    this.input = document.createElement("input");
-    this.input.type = type;
-    this.input.id = id;
-    this.input.name = id;
+export function createControllerView(
+  type: HTMLInputElementType,
+  id: string,
+  label: string,
+): ControllerView {
+  const input = document.createElement("input");
+  input.type = type;
+  input.id = id;
+  input.name = id;
 
-    this.label = document.createElement("label");
-    this.label.textContent = label;
-    this.label.htmlFor = this.input.id;
-    this.label.style.whiteSpace = "nowrap";
+  const labelElement = document.createElement("label");
+  labelElement.textContent = label;
+  labelElement.htmlFor = input.id;
+  labelElement.style.whiteSpace = "nowrap";
 
-    this.body = document.createElement("span");
-    this.body.style.whiteSpace = "nowrap";
-    this.body.appendChild(this.label);
-    this.body.appendChild(this.input);
+  const body = document.createElement("span");
+  body.style.whiteSpace = "nowrap";
+  body.appendChild(labelElement);
+  body.appendChild(input);
+
+  return { body, input, label: labelElement };
+}
+
+export function createController<T>(
+  instance: { update: () => void } & Partial<Controller<T>>,
+  type: HTMLInputElementType,
+  id: string,
+  label: string,
+): Controller<T> {
+  const view = createControllerView(type, id, label);
+  const listeners: ((e: T) => void)[] = [];
+
+  function addListeners(...ls: ((e: T) => void)[]) {
+    listeners.push(...ls);
+    instance.update();
   }
+
+  function init() {
+    view.input.addEventListener("input", instance.update.bind(instance));
+    instance.update();
+  }
+
+  Object.assign(instance, view, { listeners, addListeners, init });
+  init();
+  return instance as Controller<T>;
 }

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,43 +1,59 @@
 import { Checkbox } from "./switcher";
 import { Slider } from "./slider";
 
-class MelodyBeepVolume
-  extends Slider<number> {
-  constructor() {
-    super("melody_beep_volume", "", 0, 100, 1);
-  };
-  override updateDisplay() {
-    this.display.textContent = `volume: ${this.input.value}`;
+export interface MelodyBeepVolume extends Slider<number> {}
+export const createMelodyBeepVolume = (): MelodyBeepVolume => {
+  class Impl extends Slider<number> {
+    constructor() {
+      super("melody_beep_volume", "", 0, 100, 1);
+    }
+    override updateDisplay() {
+      this.display.textContent = `volume: ${this.input.value}`;
+    }
+    update() {
+      const value = Number(this.input.value);
+      this.listeners.forEach(e => e(value));
+    }
   }
-  update() {
-    const value = Number(this.input.value);
-    this.listeners.forEach(e => e(value));
-  }
-}
-
-class MelodyBeepSwitcher
-  extends Checkbox {
-  constructor(id: string, label: string) {
-    super(id, label);
-  }
-  update() {
-    const visibility = this.input.checked;
-    this.listeners.forEach(e => e(visibility))
-  };
+  return new Impl();
 };
 
-export class MelodyBeepController {
+export interface MelodyBeepSwitcher extends Checkbox {}
+export const createMelodyBeepSwitcher = (
+  id: string,
+  label: string,
+): MelodyBeepSwitcher => {
+  class Impl extends Checkbox {
+    constructor() {
+      super(id, label);
+    }
+    update() {
+      const visibility = this.input.checked;
+      this.listeners.forEach(e => e(visibility));
+    }
+  }
+  return new Impl();
+};
+
+export interface MelodyBeepController {
   readonly view: HTMLDivElement;
   readonly checkbox: MelodyBeepSwitcher;
   readonly volume: MelodyBeepVolume;
-  constructor() {
-    const melody_beep_switcher = new MelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
-    const melody_beep_volume = new MelodyBeepVolume();
-    this.view = document.createElement("div");
-    this.view.appendChild(melody_beep_switcher.body,);
-    this.view.appendChild(melody_beep_volume.body);
-    this.view.id = "melody-beep-controllers";
-    this.checkbox = melody_beep_switcher;
-    this.volume = melody_beep_volume;
-  };
 }
+export const createMelodyBeepController = (): MelodyBeepController => {
+  const melody_beep_switcher = createMelodyBeepSwitcher(
+    "melody_beep_switcher",
+    "Beep Melody",
+  );
+  const melody_beep_volume = createMelodyBeepVolume();
+  const view = document.createElement("div");
+  view.appendChild(melody_beep_switcher.body);
+  view.appendChild(melody_beep_volume.body);
+  view.id = "melody-beep-controllers";
+  return {
+    view,
+    checkbox: melody_beep_switcher,
+    volume: melody_beep_volume,
+  };
+};
+

--- a/packages/UI/controllers/src/melody-beep-controller.ts
+++ b/packages/UI/controllers/src/melody-beep-controller.ts
@@ -1,8 +1,9 @@
-import { Checkbox } from "./switcher";
+import { Checkbox, createCheckbox } from "./switcher";
 import { Slider } from "./slider";
 
 export interface MelodyBeepVolume extends Slider<number> {}
-export const createMelodyBeepVolume = (): MelodyBeepVolume => {
+
+export function createMelodyBeepVolume(): MelodyBeepVolume {
   class Impl extends Slider<number> {
     constructor() {
       super("melody_beep_volume", "", 0, 100, 1);
@@ -16,15 +17,13 @@ export const createMelodyBeepVolume = (): MelodyBeepVolume => {
     }
   }
   return new Impl();
-};
+}
 
 export interface MelodyBeepSwitcher extends Checkbox {}
-export const createMelodyBeepSwitcher = (
-  id: string,
-  label: string,
-): MelodyBeepSwitcher => {
+
+export function createMelodyBeepSwitcher(id: string, label: string): MelodyBeepSwitcher {
   class Impl extends Checkbox {
-    constructor() {
+    constructor(id: string, label: string) {
       super(id, label);
     }
     update() {
@@ -32,19 +31,17 @@ export const createMelodyBeepSwitcher = (
       this.listeners.forEach(e => e(visibility));
     }
   }
-  return new Impl();
-};
+  return new Impl(id, label);
+}
 
 export interface MelodyBeepController {
   readonly view: HTMLDivElement;
-  readonly checkbox: MelodyBeepSwitcher;
+  readonly checkbox: Checkbox;
   readonly volume: MelodyBeepVolume;
 }
-export const createMelodyBeepController = (): MelodyBeepController => {
-  const melody_beep_switcher = createMelodyBeepSwitcher(
-    "melody_beep_switcher",
-    "Beep Melody",
-  );
+
+export function createMelodyBeepController(): MelodyBeepController {
+  const melody_beep_switcher = createMelodyBeepSwitcher("melody_beep_switcher", "Beep Melody");
   const melody_beep_volume = createMelodyBeepVolume();
   const view = document.createElement("div");
   view.appendChild(melody_beep_switcher.body);
@@ -55,5 +52,4 @@ export const createMelodyBeepController = (): MelodyBeepController => {
     checkbox: melody_beep_switcher,
     volume: melody_beep_volume,
   };
-};
-
+}

--- a/packages/UI/controllers/src/slider.ts
+++ b/packages/UI/controllers/src/slider.ts
@@ -1,10 +1,15 @@
 import { PianoRollRatio } from "@music-analyzer/view-parameters";
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
-export abstract class Slider<T> extends Controller<T> {
+export abstract class Slider<T> implements Controller<T> {
+  body!: HTMLSpanElement;
+  input!: HTMLInputElement;
+  listeners!: ((e: T) => void)[];
+  addListeners!: (...listeners: ((e: T) => void)[]) => void;
+  init!: () => void;
   readonly display: HTMLSpanElement;
   constructor(id: string, label: string, min: number, max: number, step: number, value?: number) {
-    super ("range", id, label);
+    createController<T>(this, "range", id, label);
     this.display = document.createElement("span");
     this.body.appendChild(this.display);
 

--- a/packages/UI/controllers/src/switcher.ts
+++ b/packages/UI/controllers/src/switcher.ts
@@ -1,65 +1,83 @@
-import { Controller } from "./controller";
+import { Controller, createController } from "./controller";
 
-export class Checkbox extends Controller<boolean> {
-  constructor(id: string, label: string) {
-    super("checkbox", id, label);
+export interface Checkbox {
+  readonly body: HTMLSpanElement
+  readonly input: HTMLInputElement
+  addListeners(...listeners: ((e: boolean) => void)[]): void
+}
 
-    this.input.checked = false;
+export const createCheckbox = (id: string, label: string): Checkbox => {
+  class CheckboxImpl extends Controller<boolean> {
+    constructor() {
+      super("checkbox", id, label)
+      this.input.checked = false
+    }
+    update() {
+      this.listeners.forEach(e => e(this.input.checked))
+    }
   }
-  update() {
-    this.listeners.forEach(e=>e(this.input.checked))
+  return new CheckboxImpl()
+}
+
+export interface DMelodyController {
+  readonly view: HTMLDivElement
+  readonly checkbox: Checkbox
+  addListeners(...listeners: ((e: boolean) => void)[]): void
+}
+
+export const createDMelodyController = (): DMelodyController => {
+  const checkbox = createCheckbox("d_melody_switcher", "detected melody before fix")
+  const view = document.createElement("div")
+  view.id = "d-melody"
+  view.appendChild(checkbox.body)
+  return {
+    view,
+    checkbox,
+    addListeners: (...ls: ((e: boolean) => void)[]) => checkbox.addListeners(...ls),
   }
 }
 
-export class DMelodyController {
-  readonly view: HTMLDivElement;
-  readonly checkbox: Checkbox;
-  constructor() {
-    const d_melody_switcher = new Checkbox("d_melody_switcher", "detected melody before fix");
-    this.view = document.createElement("div");
-    this.view.id = "d-melody";
-    this.view.appendChild(d_melody_switcher.body);
-    this.checkbox = d_melody_switcher;
-  };
-  addListeners(...listeners: ((e:boolean) => void)[]) { this.checkbox.addListeners(...listeners); }
+export interface ImplicationDisplayController {
+  readonly view: HTMLDivElement
+  readonly prospective_checkbox: Checkbox
+  readonly retrospective_checkbox: Checkbox
+  readonly reconstructed_checkbox: Checkbox
 }
 
-export class ImplicationDisplayController {
-  readonly view: HTMLDivElement;
-  readonly prospective_checkbox: Checkbox;
-  readonly retrospective_checkbox: Checkbox;
-  readonly reconstructed_checkbox: Checkbox;
-  constructor() {
-    const prospective_checkbox = new Checkbox("prospective_checkbox", "prospective implication");
-    const retrospective_checkbox = new Checkbox("retrospective_checkbox", "retrospective implication");
-    const reconstructed_checkbox = new Checkbox("reconstructed_checkbox", "reconstructed implication");
-    this.view = document.createElement("div");
-    this.view.id = "prospective-implication";
-    this.view.appendChild(prospective_checkbox.body);
-    this.view.appendChild(retrospective_checkbox.body);
-    this.view.appendChild(reconstructed_checkbox.body);
-    this.prospective_checkbox = prospective_checkbox;
-    this.retrospective_checkbox = retrospective_checkbox;
-    this.reconstructed_checkbox = reconstructed_checkbox;
-  };
+export const createImplicationDisplayController = (): ImplicationDisplayController => {
+  const prospective_checkbox = createCheckbox("prospective_checkbox", "prospective implication")
+  const retrospective_checkbox = createCheckbox("retrospective_checkbox", "retrospective implication")
+  const reconstructed_checkbox = createCheckbox("reconstructed_checkbox", "reconstructed implication")
+  const view = document.createElement("div")
+  view.id = "prospective-implication"
+  view.appendChild(prospective_checkbox.body)
+  view.appendChild(retrospective_checkbox.body)
+  view.appendChild(reconstructed_checkbox.body)
+  return {
+    view,
+    prospective_checkbox,
+    retrospective_checkbox,
+    reconstructed_checkbox,
+  }
 }
 
-export class GravityController {
-  readonly view: HTMLDivElement;
-  readonly chord_checkbox: Checkbox;
-  readonly scale_checkbox: Checkbox;
-  constructor(
-    visible: boolean
-  ) {
-    const chord_gravity_switcher = new Checkbox("chord_gravity_switcher", "Chord Gravity");
-    const scale_gravity_switcher = new Checkbox("scale_gravity_switcher", "Scale Gravity");
+export interface GravityController {
+  readonly view: HTMLDivElement
+  readonly chord_checkbox: Checkbox
+  readonly scale_checkbox: Checkbox
+}
 
-    this.view = document.createElement("div");
-    this.view.id = "gravity-switcher";
-    this.view.style = visible ? "visible" : "hidden";
-    this.view.appendChild(scale_gravity_switcher.body);
-    this.view.appendChild(chord_gravity_switcher.body);
-    this.chord_checkbox = chord_gravity_switcher;
-    this.scale_checkbox = scale_gravity_switcher;
-  };
+export const createGravityController = (visible: boolean): GravityController => {
+  const chord_gravity_switcher = createCheckbox("chord_gravity_switcher", "Chord Gravity")
+  const scale_gravity_switcher = createCheckbox("scale_gravity_switcher", "Scale Gravity")
+  const view = document.createElement("div")
+  view.id = "gravity-switcher"
+  ;(view as any).style = visible ? "visible" : "hidden"
+  view.appendChild(scale_gravity_switcher.body)
+  view.appendChild(chord_gravity_switcher.body)
+  return {
+    view,
+    chord_checkbox: chord_gravity_switcher,
+    scale_checkbox: scale_gravity_switcher,
+  }
 }

--- a/packages/UI/piano-roll/beat-view/index.test.ts
+++ b/packages/UI/piano-roll/beat-view/index.test.ts
@@ -1,7 +1,28 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
+
+let dom: JSDOM;
 
 describe("piano-roll beat-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("BeatElements can be constructed", () => {
+    const { BeatElements } = require("./index");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      audio: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+    };
+
+    const beat_info = { tempo: 120, phase: 0 };
+    const melodies = [{ time: createTime(0, 1) }];
+
+    const beat = new BeatElements(beat_info, melodies, controllers);
+    expect(beat.beat_bars instanceof window.SVGGElement).toBe(true);
   });
 });

--- a/packages/UI/piano-roll/chord-view/index.test.ts
+++ b/packages/UI/piano-roll/chord-view/index.test.ts
@@ -1,7 +1,29 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("piano-roll chord-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("ChordElements can be constructed", () => {
+    const { ChordElements } = require("./index");
+    const { createSerializedTimeAndRomanAnalysis } = require("@music-analyzer/chord-analyze");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      audio: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+    };
+
+    const romans = [
+      createSerializedTimeAndRomanAnalysis(createTime(0, 1), "C", "C", "I"),
+    ];
+
+    const chord = new ChordElements(romans, controllers);
+    expect(chord.children.length).toBeGreaterThan(0);
   });
 });

--- a/packages/UI/piano-roll/chord-view/index.ts
+++ b/packages/UI/piano-roll/chord-view/index.ts
@@ -38,32 +38,36 @@ export interface RequiredByChordElements {
   readonly time_range: TimeRangeController,
 }
 
-export class ChordElements {
+export interface ChordElements {
   readonly children: SVGGElement[];
   readonly chord_keys: SVGGElement;
   readonly chord_names: SVGGElement;
   readonly chord_notes: SVGGElement;
   readonly chord_romans: SVGGElement;
-  constructor(
-    romans: SerializedTimeAndRomanAnalysis[],
-    controllers: RequiredByChordElements
-  ) {
-    const data = romans.map(e => getRequiredByChordPartModel(e))
-    const chord_keys = buildChordKeySeries(data, controllers);
-    const chord_names = buildChordNameSeries(data, controllers);
-    const chord_notes = buildChordNotesSeries(data, controllers);
-    const chord_romans = buildChordRomanSeries(data, controllers);
+}
 
-    this.chord_keys = chord_keys;
-    this.chord_names = chord_names;
-    this.chord_notes = chord_notes;
-    this.chord_romans = chord_romans;
+export function createChordElements(
+  romans: SerializedTimeAndRomanAnalysis[],
+  controllers: RequiredByChordElements
+): ChordElements {
+  const data = romans.map(e => getRequiredByChordPartModel(e));
+  const chord_keys = buildChordKeySeries(data, controllers);
+  const chord_names = buildChordNameSeries(data, controllers);
+  const chord_notes = buildChordNotesSeries(data, controllers);
+  const chord_romans = buildChordRomanSeries(data, controllers);
 
-    this.children = [
-      this.chord_keys,
-      this.chord_names,
-      this.chord_notes,
-      this.chord_romans,
-    ];
-  }
+  const children = [
+    chord_keys,
+    chord_names,
+    chord_notes,
+    chord_romans,
+  ];
+
+  return {
+    children,
+    chord_keys,
+    chord_names,
+    chord_notes,
+    chord_romans,
+  };
 }

--- a/packages/UI/piano-roll/melody-view/index.test.ts
+++ b/packages/UI/piano-roll/melody-view/index.test.ts
@@ -1,7 +1,37 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("piano-roll melody-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("createMelodyElements returns element object", () => {
+    const { createMelodyElements } = require("./index");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      gravity: { addListeners: jest.fn() },
+      audio: { addListeners: jest.fn() },
+      d_melody: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+      implication: { addListeners: jest.fn() },
+      melody_beep: { addListeners: jest.fn() },
+      melody_color: { addListeners: jest.fn() },
+      hierarchy: { addListeners: jest.fn() },
+    };
+
+    const melody = {
+      time: createTime(0, 1),
+      head: createTime(0, 0.5),
+      note: 60,
+      melody_analysis: {},
+    };
+
+    const result = createMelodyElements([[melody]], [melody], controllers);
+    expect(result.children.length).toBeGreaterThan(0);
   });
 });

--- a/packages/UI/piano-roll/melody-view/index.ts
+++ b/packages/UI/piano-roll/melody-view/index.ts
@@ -1,15 +1,7 @@
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { AudioReflectableRegistry } from "@music-analyzer/view";
 import { WindowReflectableRegistry } from "@music-analyzer/view";
-import {
-  DMelodyController,
-  GravityController,
-  HierarchyLevelController,
-  MelodyBeepController,
-  MelodyColorController,
-  TimeRangeController,
-  createMelodyBeepController,
-} from "@music-analyzer/controllers";
+import { DMelodyController, GravityController, HierarchyLevelController, type MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 
 import { buildDMelody } from "./src/d-melody-series";
 import { buildIRPlot } from "./src/ir-plot-svg";
@@ -18,7 +10,6 @@ import { buildMelody } from "./src/melody-hierarchy";
 import { buildReduction } from "./src/reduction-hierarchy";
 import { buildGravity } from "./src/gravity-hierarchy";
 import { buildIRGravity } from "./src/ir-gravity-hierarchy";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
 
 export interface RequiredByMelodyElements {
   readonly gravity: GravityController

--- a/packages/UI/piano-roll/melody-view/index.ts
+++ b/packages/UI/piano-roll/melody-view/index.ts
@@ -1,7 +1,15 @@
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { AudioReflectableRegistry } from "@music-analyzer/view";
 import { WindowReflectableRegistry } from "@music-analyzer/view";
-import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
+import {
+  DMelodyController,
+  GravityController,
+  HierarchyLevelController,
+  MelodyBeepController,
+  MelodyColorController,
+  TimeRangeController,
+  createMelodyBeepController,
+} from "@music-analyzer/controllers";
 
 import { buildDMelody } from "./src/d-melody-series";
 import { buildIRPlot } from "./src/ir-plot-svg";

--- a/packages/UI/piano-roll/melody-view/src/ir-gravity-hierarchy.ts
+++ b/packages/UI/piano-roll/melody-view/src/ir-gravity-hierarchy.ts
@@ -5,7 +5,7 @@ import { Time } from "@music-analyzer/time-and";
 import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
 import { HierarchyLevelController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 import { GetColor } from "@music-analyzer/controllers/src/color-selector";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
+import { ImplicationDisplayController } from "@music-analyzer/controllers";
 import { ITriad } from "@music-analyzer/irm";
 
 interface IRGravityModel {

--- a/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
+++ b/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
@@ -5,7 +5,13 @@ import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze"
 import { play } from "@music-analyzer/synth";
 import { black_key_height, NowAt, PianoRollConverter } from "@music-analyzer/view-parameters";
 import { reservation_range } from "@music-analyzer/view-parameters";
-import { HierarchyLevelController, MelodyBeepController, MelodyColorController, SetColor, TimeRangeController } from "@music-analyzer/controllers";
+import {
+  HierarchyLevelController,
+  MelodyBeepController,
+  MelodyColorController,
+  SetColor,
+  TimeRangeController,
+} from "@music-analyzer/controllers";
 import { Time, createTime } from "@music-analyzer/time-and";
 import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
 

--- a/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
+++ b/packages/UI/piano-roll/melody-view/src/melody-hierarchy.ts
@@ -5,13 +5,7 @@ import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze"
 import { play } from "@music-analyzer/synth";
 import { black_key_height, NowAt, PianoRollConverter } from "@music-analyzer/view-parameters";
 import { reservation_range } from "@music-analyzer/view-parameters";
-import {
-  HierarchyLevelController,
-  MelodyBeepController,
-  MelodyColorController,
-  SetColor,
-  TimeRangeController,
-} from "@music-analyzer/controllers";
+import { HierarchyLevelController, type MelodyBeepController, MelodyColorController, SetColor, TimeRangeController } from "@music-analyzer/controllers";
 import { Time, createTime } from "@music-analyzer/time-and";
 import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
 

--- a/packages/UI/piano-roll/melody-view/src/reduction-tree.ts
+++ b/packages/UI/piano-roll/melody-view/src/reduction-tree.ts
@@ -1,5 +1,5 @@
 import { PianoRollConverter } from "@music-analyzer/view-parameters";
-import { DMelodyController, GravityController, HierarchyLevelController, MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
+import { DMelodyController, GravityController, HierarchyLevelController, type MelodyBeepController, MelodyColorController, TimeRangeController } from "@music-analyzer/controllers";
 import { AudioReflectableRegistry, WindowReflectableRegistry } from "@music-analyzer/view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 
@@ -29,24 +29,20 @@ interface RequiredByTreeHierarchy {
   readonly time_range: TimeRangeController
 }
 
-export class TreeHierarchy {
-  constructor(
-    readonly svg: SVGGElement,
-  ) {
-  }
-  onChangedLayer(value: number){
-
-  }
-  onAudioUpdate(){
-
-  }
-  onWindowResized(){
-
-  }
-  onTimeRangeChanged(){
-
-  }
+export interface TreeHierarchy {
+  readonly svg: SVGGElement;
+  onChangedLayer(value: number): void;
+  onAudioUpdate(): void;
+  onWindowResized(): void;
+  onTimeRangeChanged(): void;
 }
+export const createTreeHierarchy = (svg: SVGGElement): TreeHierarchy => ({
+  svg,
+  onChangedLayer: () => {},
+  onAudioUpdate: () => {},
+  onWindowResized: () => {},
+  onTimeRangeChanged: () => {},
+});
 
 export function buildTree(
     h_melodies: SerializedTimeAndAnalyzedMelody[][],
@@ -99,12 +95,12 @@ export function buildTree(
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "g");
   svg.id = "reduction-tree";
 
-  const hierarchy = new TreeHierarchy(svg)
+  const hierarchy = createTreeHierarchy(svg)
 
-  controllers.hierarchy.addListeners(hierarchy.onChangedLayer.bind(hierarchy));
-  controllers.audio.addListeners(hierarchy.onAudioUpdate.bind(hierarchy));
-  controllers.window.addListeners(hierarchy.onWindowResized.bind(hierarchy));
-  controllers.time_range.addListeners(hierarchy.onTimeRangeChanged.bind(hierarchy))
+  controllers.hierarchy.addListeners(hierarchy.onChangedLayer);
+  controllers.audio.addListeners(hierarchy.onAudioUpdate);
+  controllers.window.addListeners(hierarchy.onWindowResized);
+  controllers.time_range.addListeners(hierarchy.onTimeRangeChanged)
 
   return hierarchy;
 

--- a/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
+++ b/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
@@ -1,7 +1,7 @@
 import { BeatInfo } from "@music-analyzer/beat-estimation";
 import { BeatElements } from "@music-analyzer/beat-view";
 import { SerializedTimeAndRomanAnalysis } from "@music-analyzer/chord-analyze";
-import { ChordElements } from "@music-analyzer/chord-view";
+import { ChordElements, createChordElements } from "@music-analyzer/chord-view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { MelodyElements, createMelodyElements } from "@music-analyzer/melody-view";
 import { RequiredByBeatElements } from "@music-analyzer/beat-view";
@@ -21,7 +21,7 @@ export class MusicStructureElements {
     controllers: RequiredByBeatElements & RequiredByChordElements & RequiredByMelodyElements
   ) {
     this.beat = new BeatElements(beat_info, melodies, controllers)
-    this.chord = new ChordElements(romans, controllers)
+    this.chord = createChordElements(romans, controllers)
     this.melody = createMelodyElements(hierarchical_melody, d_melodies, controllers)
   }
 }

--- a/packages/UI/spectrogram/index.test.ts
+++ b/packages/UI/spectrogram/index.test.ts
@@ -1,0 +1,32 @@
+import { JSDOM } from "jsdom";
+
+describe("spectrogram module", () => {
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+
+    class MockAudioNode { connect() {} }
+    class MockAnalyserNode extends MockAudioNode {
+      fftSize = 1024;
+      getByteTimeDomainData() { return new Uint8Array(1024); }
+      getFloatFrequencyData() { return new Float32Array(1024); }
+    }
+    class MockAudioContext {
+      destination = new MockAudioNode();
+      createMediaElementSource() { return new MockAudioNode(); }
+      createAnalyser() { return new MockAnalyserNode(); }
+    }
+    (global as any).AudioContext = MockAudioContext;
+  });
+
+  test("AudioViewer can be instantiated", () => {
+    const { AudioViewer } = require("./index");
+    const audio = { addEventListener: jest.fn() } as any;
+    const registry = { addListeners: jest.fn() };
+    const viewer = new AudioViewer(audio, registry);
+    expect(viewer).toBeTruthy();
+    expect(() => viewer.onAudioUpdate()).not.toThrow();
+  });
+});

--- a/packages/UI/spectrogram/index.ts
+++ b/packages/UI/spectrogram/index.ts
@@ -1,1 +1,2 @@
-export { AudioViewer } from "./src/audio-viewer";
+export type { AudioViewer } from "./src/audio-viewer";
+export { createAudioViewer } from "./src/audio-viewer";

--- a/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
@@ -7,24 +7,32 @@ import { getFFT } from "./get-fft";
 
 const resumeAudioCtx = (audioCtx: AudioContext) => () => { audioCtx.state === 'suspended' && audioCtx.resume(); }
 
-export class AudioAnalyzer {
-  private readonly audioCtx: AudioContext;
-  private readonly source: MediaElementAudioSourceNode;
+export interface AudioAnalyzer {
   readonly analyser: AnalyserNode;
-
-  constructor(audioElement: HTMLAudioElement) {
-    this.audioCtx = new AudioContext();
-    this.source = this.audioCtx.createMediaElementSource(audioElement);
-    this.analyser = this.audioCtx.createAnalyser();
-
-    audioElement.addEventListener("play", resumeAudioCtx(this.audioCtx));
-    this.analyser.fftSize = 1024;
-    connect(this.source, this.analyser, this.audioCtx.destination);
-  }
-
-  getByteTimeDomainData() { return getByteTimeDomainData(this.analyser); }
-  getFloatTimeDomainData() { return getFloatTimeDomainData(this.analyser); }
-  getByteFrequencyData() { return getByteFrequencyData(this.analyser); }
-  getFloatFrequencyData() { return getFloatFrequencyData(this.analyser); }
-  getFFT() { return getFFT(this.analyser); }
+  getByteTimeDomainData(): Uint8Array<ArrayBuffer>;
+  getFloatTimeDomainData(): Float32Array<ArrayBuffer>;
+  getByteFrequencyData(): Uint8Array<ArrayBuffer>;
+  getFloatFrequencyData(): Float32Array<ArrayBuffer>;
+  getFFT(): [Float32Array<ArrayBuffer>, Float32Array<ArrayBuffer>];
 }
+
+export const createAudioAnalyzer = (
+  audioElement: HTMLAudioElement,
+): AudioAnalyzer => {
+  const audioCtx = new AudioContext();
+  const source = audioCtx.createMediaElementSource(audioElement);
+  const analyser = audioCtx.createAnalyser();
+
+  audioElement.addEventListener("play", resumeAudioCtx(audioCtx));
+  analyser.fftSize = 1024;
+  connect(source, analyser, audioCtx.destination);
+
+  return {
+    analyser,
+    getByteTimeDomainData: () => getByteTimeDomainData(analyser),
+    getFloatTimeDomainData: () => getFloatTimeDomainData(analyser),
+    getByteFrequencyData: () => getByteFrequencyData(analyser),
+    getFloatFrequencyData: () => getFloatFrequencyData(analyser),
+    getFFT: () => getFFT(analyser),
+  };
+};

--- a/packages/UI/spectrogram/src/audio-analyzer/index.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/index.ts
@@ -1,1 +1,2 @@
-export { AudioAnalyzer } from "./audio-analyzer";
+export type { AudioAnalyzer } from "./audio-analyzer";
+export { createAudioAnalyzer } from "./audio-analyzer";

--- a/packages/UI/spectrogram/src/audio-viewer.ts
+++ b/packages/UI/spectrogram/src/audio-viewer.ts
@@ -1,28 +1,33 @@
 import { AudioReflectableRegistry } from "@music-analyzer/view";
-import { WaveViewer } from "./wave-viewer";
-import { spectrogramViewer } from "./spectrogram-viewer";
-import { AudioAnalyzer } from "./audio-analyzer";
-import { FFTViewer } from "./fft-viewer";
+import { WaveViewer, createWaveViewer } from "./wave-viewer";
+import { spectrogramViewer, createSpectrogramViewer } from "./spectrogram-viewer";
+import { AudioAnalyzer, createAudioAnalyzer } from "./audio-analyzer";
+import { FFTViewer, createFFTViewer } from "./fft-viewer";
 
 // AudioAnalyzer.ts
-export class AudioViewer {
+export interface AudioViewer {
   readonly wave: WaveViewer;
   readonly spectrogram: spectrogramViewer;
   readonly fft: FFTViewer;
-
-  constructor(
-    private readonly audio_element: HTMLMediaElement,
-    audio_registry: AudioReflectableRegistry
-  ) {
-    const analyser = new AudioAnalyzer(this.audio_element);
-    this.wave = new WaveViewer(analyser);
-    this.spectrogram = new spectrogramViewer(analyser);
-    this.fft = new FFTViewer(analyser)
-    audio_registry.addListeners(this.onAudioUpdate.bind(this));
-  }
-  onAudioUpdate() {
-    this.wave.onAudioUpdate();
-    this.spectrogram.onAudioUpdate();
-    this.fft.onAudioUpdate();
-  }
+  onAudioUpdate(): void;
 }
+
+export const createAudioViewer = (
+  audio_element: HTMLMediaElement,
+  audio_registry: AudioReflectableRegistry,
+): AudioViewer => {
+  const analyser = createAudioAnalyzer(audio_element);
+  const wave = createWaveViewer(analyser);
+  const spectrogram = createSpectrogramViewer(analyser);
+  const fft = createFFTViewer(analyser);
+
+  const onAudioUpdate = () => {
+    wave.onAudioUpdate();
+    spectrogram.onAudioUpdate();
+    fft.onAudioUpdate();
+  };
+
+  audio_registry.addListeners(onAudioUpdate);
+
+  return { wave, spectrogram, fft, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/fft-viewer.ts
+++ b/packages/UI/spectrogram/src/fft-viewer.ts
@@ -1,34 +1,35 @@
 import { Complex } from "@music-analyzer/math";
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class FFTViewer {
-  private readonly path: SVGPathElement;
+export interface FFTViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "rgb(192,0,255)");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "fft";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
+  onAudioUpdate(): void;
+}
 
-  onAudioUpdate() {
-    const freqData = this.analyser.getFFT();
+export const createFFTViewer = (
+  analyser: AudioAnalyzer,
+): FFTViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "rgb(192,0,255)");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "fft";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFFT();
     const N = freqData[0].length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let pathData = "";
 
     const abs = <T extends number>(e: Complex<T>) => Math.sqrt(e.re * e.re + e.im * e.im)
     const absV = (...c: [Float32Array<ArrayBuffer>, Float32Array<ArrayBuffer>]) =>
       c[0].map((e, i) => Math.sqrt(e * e + c[1][i] * c[1][i]))
 
-    this.path.setAttribute("d", "M" +
+    path.setAttribute("d", "M" +
 //      freqData.map(e => abs(e))
         [...Array.from(absV(...freqData))]
         .map((e, i) => {
@@ -48,7 +49,9 @@ export class FFTViewer {
       const y = (1 - Math.log2(1 + abs(freqData[i])) / 8) * height;
       pathData += `L ${x},${y}`;
     }
-    this.path.setAttribute("d", "M" + pathData.slice(1));
+    path.setAttribute("d", "M" + pathData.slice(1));
     */
-  }
-}
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/spectrogram-viewer.ts
+++ b/packages/UI/spectrogram/src/spectrogram-viewer.ts
@@ -1,26 +1,27 @@
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class spectrogramViewer {
-  private readonly path: SVGPathElement;
+export interface spectrogramViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "red");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "spectrum";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
+  onAudioUpdate(): void;
+}
 
-  onAudioUpdate() {
-    const freqData = this.analyser.getFloatFrequencyData();
+export const createSpectrogramViewer = (
+  analyser: AudioAnalyzer,
+): spectrogramViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "red");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "spectrum";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFloatFrequencyData();
     const fftSize = freqData.length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let pathData = "";
 
     for (let i = 0; i < fftSize; i++) {
@@ -32,6 +33,8 @@ export class spectrogramViewer {
     [pathData]
       .map(e => e.slice(1))
       .filter(e => e.length > 0)
-      .map(e => this.path.setAttribute("d", "M" + e))
-  }
-}
+      .map(e => path.setAttribute("d", "M" + e));
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/synth/index.test.ts
+++ b/packages/UI/synth/index.test.ts
@@ -1,7 +1,49 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("synth module", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  beforeAll(() => {
+    const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+
+    class MockAudioNode {
+      connect() {}
+    }
+
+    class MockGainNode extends MockAudioNode {
+      gain = { value: 0, cancelScheduledValues: jest.fn(), linearRampToValueAtTime: jest.fn(), exponentialRampToValueAtTime: jest.fn() };
+    }
+
+    class MockOscillatorNode extends MockAudioNode {
+      type: OscillatorType = "sine";
+      frequency = { value: 0 };
+      detune = { value: 0 };
+      start() {}
+      stop() {}
+    }
+
+    class MockAudioContext {
+      destination = new MockGainNode();
+      currentTime = 0;
+      createGain() { return new MockGainNode(); }
+      createOscillator() { return new MockOscillatorNode(); }
+    }
+
+    (global as any).AudioContext = MockAudioContext;
+  });
+
+  test("factory functions operate without error", () => {
+    const { createGain, createOscillator, play, play_note } = require("./index");
+    const ctx = new AudioContext();
+    const parent = ctx.destination;
+
+    const g = createGain(ctx, parent, 0.5);
+    expect(g.gain.value).toBe(0.5);
+
+    const o = createOscillator(ctx, parent, "square", 440, 0);
+    expect(o.frequency.value).toBe(440);
+
+    expect(() => play([440], 0, 0.1)).not.toThrow();
+    expect(() => play_note([440], 60, 4)).not.toThrow();
   });
 });

--- a/packages/UI/view-parameters/index.ts
+++ b/packages/UI/view-parameters/index.ts
@@ -4,21 +4,23 @@ export const size = 2;
 export const octave_height = size * 84;  // 7 白鍵と 12 半音をきれいに描画するには 7 * 12 の倍数が良い
 export const black_key_height = octave_height / 12;
 
-export class NowAt {
-  constructor(readonly value: number) { }
+export interface NowAt { readonly value: number }
+export const createNowAt = (value: number): NowAt => ({ value });
 
-  static #value = 0;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
+let nowAtValue = 0;
+export const NowAt = {
+  get: () => nowAtValue,
+  set: (value: number) => { nowAtValue = value },
+};
 
-export class PianoRollRatio {
-  constructor(readonly value: number) { }
+export interface PianoRollRatio { readonly value: number }
+export const createPianoRollRatio = (value: number): PianoRollRatio => ({ value });
 
-  static #value: number = 1;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
+let pianoRollRatioValue: number = 1;
+export const PianoRollRatio = {
+  get: () => pianoRollRatioValue,
+  set: (value: number) => { pianoRollRatioValue = value },
+};
 
 class PianoRollTimeLength {
   constructor(
@@ -30,15 +32,14 @@ class PianoRollTimeLength {
   static get() { return PianoRollRatio.get() * SongLength.get(); }
 }
 
-export class NoteSize {
-  constructor(
-    private readonly width: PianoRollWidth,
-    private readonly length: PianoRollTimeLength,
-  ) { }
-  _get() { return this.width._get() / this.length._get(); }
+export interface NoteSize { get: () => number }
+export const createNoteSize = (width: PianoRollWidth, length: PianoRollTimeLength): NoteSize => ({
+  get: () => width.get() / length._get(),
+});
 
-  static get() { return PianoRollWidth.get() / PianoRollTimeLength.get(); }
-}
+export const NoteSize: NoteSize = {
+  get: () => PianoRollWidth.get() / PianoRollTimeLength.get(),
+};
 
 const transposed = (e: number) => e - PianoRollBegin.get();
 const scaled = (e: number) => e * NoteSize.get();
@@ -73,57 +74,61 @@ class CurrentTimeRatio {
   static set(value: number) { this.#value = value; }
 }
 
-export class CurrentTimeX {
-  constructor(
-    private readonly width: PianoRollWidth,
-    private readonly ratio: CurrentTimeRatio,
-  ) { }
-  _get() { return this.width._get() * this.ratio.value; }
+export interface CurrentTimeX { get: () => number }
+export const createCurrentTimeX = (width: PianoRollWidth, ratio: CurrentTimeRatio): CurrentTimeX => ({
+  get: () => width.get() * ratio.value,
+});
 
-  static get() {
-    return PianoRollWidth.get() * CurrentTimeRatio.get();
-  }
-}
-export class OctaveCount {
-  constructor(
-    private readonly end: PianoRollEnd,
-    private readonly begin: PianoRollBegin,
-  ) { }
-  _get() { return Math.ceil(-(this.end.value - this.begin.value) / 12); }
+export const CurrentTimeX: CurrentTimeX = {
+  get: () => PianoRollWidth.get() * CurrentTimeRatio.get(),
+};
+export interface OctaveCount { get: () => number }
+export const createOctaveCount = (end: PianoRollEnd, begin: PianoRollBegin): OctaveCount => ({
+  get: () => Math.ceil(-(end.value - begin.value) / 12),
+});
 
-  static get() { return Math.ceil(-(PianoRollEnd.get() - PianoRollBegin.get()) / 12); }
-}
-export class PianoRollBegin {
-  constructor(readonly value: number) { }
+export const OctaveCount: OctaveCount = {
+  get: () => Math.ceil(-(PianoRollEnd.get() - PianoRollBegin.get()) / 12),
+};
+export interface PianoRollBegin { readonly value: number }
+export const createPianoRollBegin = (value: number): PianoRollBegin => ({ value });
 
-  static #value = 83;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-export class PianoRollEnd {
-  constructor(readonly value: number) { }
+let pianoRollBeginValue = 83;
+export const PianoRollBegin = {
+  get: () => pianoRollBeginValue,
+  set: (value: number) => { pianoRollBeginValue = value },
+};
+export interface PianoRollEnd { readonly value: number }
+export const createPianoRollEnd = (value: number): PianoRollEnd => ({ value });
 
-  static #value = 83 + 24;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-export class PianoRollHeight {
-  constructor(
-    private readonly count: OctaveCount
-  ) { }
-  _get() { return octave_height * this.count._get(); }
+let pianoRollEndValue = 83 + 24;
+export const PianoRollEnd = {
+  get: () => pianoRollEndValue,
+  set: (value: number) => { pianoRollEndValue = value },
+};
+export interface PianoRollHeight { get: () => number }
+export const createPianoRollHeight = (count: OctaveCount): PianoRollHeight => ({
+  get: () => octave_height * count.get(),
+});
 
-  static get() { return octave_height * OctaveCount.get(); }
-}
-class WindowInnerWidth {
-  _get() { return window.innerWidth; }
-  static get() { return window.innerWidth; }
-}
+export const PianoRollHeight: PianoRollHeight = {
+  get: () => octave_height * OctaveCount.get(),
+};
+export interface WindowInnerWidth { get: () => number }
+export const createWindowInnerWidth = (): WindowInnerWidth => ({ get: () => window.innerWidth });
 
-export class PianoRollWidth {
-  _get() { return window.innerWidth - 48; }
-  static get() { return WindowInnerWidth.get() - 48; }
-}
+export const WindowInnerWidth: WindowInnerWidth = {
+  get: () => window.innerWidth,
+};
+
+export interface PianoRollWidth { get: () => number }
+export const createPianoRollWidth = (windowWidth: WindowInnerWidth): PianoRollWidth => ({
+  get: () => windowWidth.get() - 48,
+});
+
+export const PianoRollWidth: PianoRollWidth = {
+  get: () => WindowInnerWidth.get() - 48,
+};
 class SongLength {
   constructor(readonly value: number) { }
 


### PR DESCRIPTION
## Summary
- refactor MelodyBeepController and helpers into interfaces with factory creators
- update controller exports
- use `createMelodyBeepController()` in analyze app
- adjust melody view imports

## Testing
- `yarn build` *(fails: Could not resolve "./key-estimation/chord-progression")*
- `yarn test` *(fails: AudioContext is not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68423c8e327483329e4aab188b8c919d