### PR TITLE
Convert ChordElements class to factory

### DIFF
--- a/packages/UI/piano-roll/chord-view/index.ts
+++ b/packages/UI/piano-roll/chord-view/index.ts
@@ -38,32 +38,36 @@ export interface RequiredByChordElements {
   readonly time_range: TimeRangeController,
 }
 
-export class ChordElements {
+export interface ChordElements {
   readonly children: SVGGElement[];
   readonly chord_keys: SVGGElement;
   readonly chord_names: SVGGElement;
   readonly chord_notes: SVGGElement;
   readonly chord_romans: SVGGElement;
-  constructor(
-    romans: SerializedTimeAndRomanAnalysis[],
-    controllers: RequiredByChordElements
-  ) {
-    const data = romans.map(e => getRequiredByChordPartModel(e))
-    const chord_keys = buildChordKeySeries(data, controllers);
-    const chord_names = buildChordNameSeries(data, controllers);
-    const chord_notes = buildChordNotesSeries(data, controllers);
-    const chord_romans = buildChordRomanSeries(data, controllers);
+}
 
-    this.chord_keys = chord_keys;
-    this.chord_names = chord_names;
-    this.chord_notes = chord_notes;
-    this.chord_romans = chord_romans;
+export function createChordElements(
+  romans: SerializedTimeAndRomanAnalysis[],
+  controllers: RequiredByChordElements,
+): ChordElements {
+  const data = romans.map(e => getRequiredByChordPartModel(e));
+  const chord_keys = buildChordKeySeries(data, controllers);
+  const chord_names = buildChordNameSeries(data, controllers);
+  const chord_notes = buildChordNotesSeries(data, controllers);
+  const chord_romans = buildChordRomanSeries(data, controllers);
 
-    this.children = [
-      this.chord_keys,
-      this.chord_names,
-      this.chord_notes,
-      this.chord_romans,
-    ];
-  }
+  const children = [
+    chord_keys,
+    chord_names,
+    chord_notes,
+    chord_romans,
+  ];
+
+  return {
+    children,
+    chord_keys,
+    chord_names,
+    chord_notes,
+    chord_romans,
+  };
 }

--- a/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
+++ b/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
@@ -1,7 +1,7 @@
 import { BeatInfo } from "@music-analyzer/beat-estimation";
 import { BeatElements } from "@music-analyzer/beat-view";
 import { SerializedTimeAndRomanAnalysis } from "@music-analyzer/chord-analyze";
-import { ChordElements } from "@music-analyzer/chord-view";
+import { ChordElements, createChordElements } from "@music-analyzer/chord-view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
 import { MelodyElements, createMelodyElements } from "@music-analyzer/melody-view";
 import { RequiredByBeatElements } from "@music-analyzer/beat-view";
@@ -21,7 +21,7 @@ export class MusicStructureElements {
     controllers: RequiredByBeatElements & RequiredByChordElements & RequiredByMelodyElements
   ) {
     this.beat = new BeatElements(beat_info, melodies, controllers)
-    this.chord = new ChordElements(romans, controllers)
+    this.chord = createChordElements(romans, controllers)
     this.melody = createMelodyElements(hierarchical_melody, d_melodies, controllers)
   }
 }


### PR DESCRIPTION
## Summary
- refactor chord-view to use interface + factory
- update piano-roll to create chord elements via factory

## Testing
- `yarn test` *(fails: AudioContext not defined and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68423c92a0d883329e4227ecc15c35f6