### PR TITLE
Refactor spectrogram module factories

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -1,7 +1,7 @@
 import { setCurrentTimeRatio, setPianoRollParameters } from "@music-analyzer/view-parameters";
 import { song_list } from "@music-analyzer/gttm";
 import { createAnalyzedDataContainer } from "@music-analyzer/analyzed-data-container";
-import { AudioViewer } from "@music-analyzer/spectrogram";
+import { createAudioViewer, AudioViewer } from "@music-analyzer/spectrogram";
 import { PianoRoll } from "@music-analyzer/piano-roll";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { PianoRollWidth } from "@music-analyzer/view-parameters";
@@ -325,7 +325,7 @@ const setupUI = (
   piano_roll_place: HTMLDivElement,
   manager: ApplicationManager,
 ) => {
-  const audio_viewer = new AudioViewer(audio_player, manager.audio_time_mediator);
+  const audio_viewer = createAudioViewer(audio_player, manager.audio_time_mediator);
   const piano_roll_view = new PianoRoll(manager.analyzed, manager.window_size_mediator, !manager.FULL_VIEW)
   asParent(piano_roll_place)
     .appendChildren(

--- a/packages/UI/spectrogram/index.ts
+++ b/packages/UI/spectrogram/index.ts
@@ -1,1 +1,2 @@
-export { AudioViewer } from "./src/audio-viewer";
+export type { AudioViewer } from "./src/audio-viewer";
+export { createAudioViewer } from "./src/audio-viewer";

--- a/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
@@ -7,24 +7,32 @@ import { getFFT } from "./get-fft";
 
 const resumeAudioCtx = (audioCtx: AudioContext) => () => { audioCtx.state === 'suspended' && audioCtx.resume(); }
 
-export class AudioAnalyzer {
-  private readonly audioCtx: AudioContext;
-  private readonly source: MediaElementAudioSourceNode;
+export interface AudioAnalyzer {
   readonly analyser: AnalyserNode;
-
-  constructor(audioElement: HTMLAudioElement) {
-    this.audioCtx = new AudioContext();
-    this.source = this.audioCtx.createMediaElementSource(audioElement);
-    this.analyser = this.audioCtx.createAnalyser();
-
-    audioElement.addEventListener("play", resumeAudioCtx(this.audioCtx));
-    this.analyser.fftSize = 1024;
-    connect(this.source, this.analyser, this.audioCtx.destination);
-  }
-
-  getByteTimeDomainData() { return getByteTimeDomainData(this.analyser); }
-  getFloatTimeDomainData() { return getFloatTimeDomainData(this.analyser); }
-  getByteFrequencyData() { return getByteFrequencyData(this.analyser); }
-  getFloatFrequencyData() { return getFloatFrequencyData(this.analyser); }
-  getFFT() { return getFFT(this.analyser); }
+  getByteTimeDomainData(): Uint8Array<ArrayBuffer>;
+  getFloatTimeDomainData(): Float32Array<ArrayBuffer>;
+  getByteFrequencyData(): Uint8Array<ArrayBuffer>;
+  getFloatFrequencyData(): Float32Array<ArrayBuffer>;
+  getFFT(): [Float32Array<ArrayBuffer>, Float32Array<ArrayBuffer>];
 }
+
+export const createAudioAnalyzer = (
+  audioElement: HTMLAudioElement,
+): AudioAnalyzer => {
+  const audioCtx = new AudioContext();
+  const source = audioCtx.createMediaElementSource(audioElement);
+  const analyser = audioCtx.createAnalyser();
+
+  audioElement.addEventListener("play", resumeAudioCtx(audioCtx));
+  analyser.fftSize = 1024;
+  connect(source, analyser, audioCtx.destination);
+
+  return {
+    analyser,
+    getByteTimeDomainData: () => getByteTimeDomainData(analyser),
+    getFloatTimeDomainData: () => getFloatTimeDomainData(analyser),
+    getByteFrequencyData: () => getByteFrequencyData(analyser),
+    getFloatFrequencyData: () => getFloatFrequencyData(analyser),
+    getFFT: () => getFFT(analyser),
+  };
+};

--- a/packages/UI/spectrogram/src/audio-analyzer/index.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/index.ts
@@ -1,1 +1,2 @@
-export { AudioAnalyzer } from "./audio-analyzer";
+export type { AudioAnalyzer } from "./audio-analyzer";
+export { createAudioAnalyzer } from "./audio-analyzer";

--- a/packages/UI/spectrogram/src/audio-viewer.ts
+++ b/packages/UI/spectrogram/src/audio-viewer.ts
@@ -1,28 +1,33 @@
 import { AudioReflectableRegistry } from "@music-analyzer/view";
-import { WaveViewer } from "./wave-viewer";
-import { spectrogramViewer } from "./spectrogram-viewer";
-import { AudioAnalyzer } from "./audio-analyzer";
-import { FFTViewer } from "./fft-viewer";
+import { WaveViewer, createWaveViewer } from "./wave-viewer";
+import { spectrogramViewer, createSpectrogramViewer } from "./spectrogram-viewer";
+import { AudioAnalyzer, createAudioAnalyzer } from "./audio-analyzer";
+import { FFTViewer, createFFTViewer } from "./fft-viewer";
 
 // AudioAnalyzer.ts
-export class AudioViewer {
+export interface AudioViewer {
   readonly wave: WaveViewer;
   readonly spectrogram: spectrogramViewer;
   readonly fft: FFTViewer;
-
-  constructor(
-    private readonly audio_element: HTMLMediaElement,
-    audio_registry: AudioReflectableRegistry
-  ) {
-    const analyser = new AudioAnalyzer(this.audio_element);
-    this.wave = new WaveViewer(analyser);
-    this.spectrogram = new spectrogramViewer(analyser);
-    this.fft = new FFTViewer(analyser)
-    audio_registry.addListeners(this.onAudioUpdate.bind(this));
-  }
-  onAudioUpdate() {
-    this.wave.onAudioUpdate();
-    this.spectrogram.onAudioUpdate();
-    this.fft.onAudioUpdate();
-  }
+  onAudioUpdate(): void;
 }
+
+export const createAudioViewer = (
+  audio_element: HTMLMediaElement,
+  audio_registry: AudioReflectableRegistry,
+): AudioViewer => {
+  const analyser = createAudioAnalyzer(audio_element);
+  const wave = createWaveViewer(analyser);
+  const spectrogram = createSpectrogramViewer(analyser);
+  const fft = createFFTViewer(analyser);
+
+  const onAudioUpdate = () => {
+    wave.onAudioUpdate();
+    spectrogram.onAudioUpdate();
+    fft.onAudioUpdate();
+  };
+
+  audio_registry.addListeners(onAudioUpdate);
+
+  return { wave, spectrogram, fft, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/fft-viewer.ts
+++ b/packages/UI/spectrogram/src/fft-viewer.ts
@@ -1,34 +1,35 @@
 import { Complex } from "@music-analyzer/math";
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class FFTViewer {
-  private readonly path: SVGPathElement;
+export interface FFTViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "rgb(192,0,255)");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "fft";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
+  onAudioUpdate(): void;
+}
 
-  onAudioUpdate() {
-    const freqData = this.analyser.getFFT();
+export const createFFTViewer = (
+  analyser: AudioAnalyzer,
+): FFTViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "rgb(192,0,255)");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "fft";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFFT();
     const N = freqData[0].length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let pathData = "";
 
     const abs = <T extends number>(e: Complex<T>) => Math.sqrt(e.re * e.re + e.im * e.im)
     const absV = (...c: [Float32Array<ArrayBuffer>, Float32Array<ArrayBuffer>]) =>
       c[0].map((e, i) => Math.sqrt(e * e + c[1][i] * c[1][i]))
 
-    this.path.setAttribute("d", "M" +
+    path.setAttribute("d", "M" +
 //      freqData.map(e => abs(e))
         [...Array.from(absV(...freqData))]
         .map((e, i) => {
@@ -48,7 +49,9 @@ export class FFTViewer {
       const y = (1 - Math.log2(1 + abs(freqData[i])) / 8) * height;
       pathData += `L ${x},${y}`;
     }
-    this.path.setAttribute("d", "M" + pathData.slice(1));
+    path.setAttribute("d", "M" + pathData.slice(1));
     */
-  }
-}
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/spectrogram-viewer.ts
+++ b/packages/UI/spectrogram/src/spectrogram-viewer.ts
@@ -1,26 +1,27 @@
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class spectrogramViewer {
-  private readonly path: SVGPathElement;
+export interface spectrogramViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "red");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "spectrum";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
+  onAudioUpdate(): void;
+}
 
-  onAudioUpdate() {
-    const freqData = this.analyser.getFloatFrequencyData();
+export const createSpectrogramViewer = (
+  analyser: AudioAnalyzer,
+): spectrogramViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "red");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "spectrum";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFloatFrequencyData();
     const fftSize = freqData.length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let pathData = "";
 
     for (let i = 0; i < fftSize; i++) {
@@ -32,6 +33,8 @@ export class spectrogramViewer {
     [pathData]
       .map(e => e.slice(1))
       .filter(e => e.length > 0)
-      .map(e => this.path.setAttribute("d", "M" + e))
-  }
-}
+      .map(e => path.setAttribute("d", "M" + e));
+  };
+
+  return { svg, onAudioUpdate };
+};


### PR DESCRIPTION
## Summary
- expose factory functions in spectrogram package
- refactor spectrogram viewers to be created via factories
- update audio-viewer and its consumers to use the new API

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: turbo not found)*
- `npx tsc -p packages/UI/spectrogram/tsconfig.json` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68423c95ffcc8332aa2e0bb24609d5c4