### PR TITLE
Update UI tests to use factory functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/jsdom": "^21.1.7",
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.26.0",
     "depcheck": "^1.4.7",
@@ -37,6 +38,7 @@
     "eslint": "^9.21.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
+    "jsdom": "^26.1.0",
     "madge": "^8.0.0",
     "ts-jest": "^29.2.6",
     "tsup": "^8.4.0",

--- a/packages/UI/piano-roll/beat-view/index.test.ts
+++ b/packages/UI/piano-roll/beat-view/index.test.ts
@@ -1,7 +1,28 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
+
+let dom: JSDOM;
 
 describe("piano-roll beat-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("BeatElements can be constructed", () => {
+    const { BeatElements } = require("./index");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      audio: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+    };
+
+    const beat_info = { tempo: 120, phase: 0 };
+    const melodies = [{ time: createTime(0, 1) }];
+
+    const beat = new BeatElements(beat_info, melodies, controllers);
+    expect(beat.beat_bars instanceof window.SVGGElement).toBe(true);
   });
 });

--- a/packages/UI/piano-roll/chord-view/index.test.ts
+++ b/packages/UI/piano-roll/chord-view/index.test.ts
@@ -1,7 +1,29 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("piano-roll chord-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("ChordElements can be constructed", () => {
+    const { ChordElements } = require("./index");
+    const { createSerializedTimeAndRomanAnalysis } = require("@music-analyzer/chord-analyze");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      audio: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+    };
+
+    const romans = [
+      createSerializedTimeAndRomanAnalysis(createTime(0, 1), "C", "C", "I"),
+    ];
+
+    const chord = new ChordElements(romans, controllers);
+    expect(chord.children.length).toBeGreaterThan(0);
   });
 });

--- a/packages/UI/piano-roll/melody-view/index.test.ts
+++ b/packages/UI/piano-roll/melody-view/index.test.ts
@@ -1,7 +1,37 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("piano-roll melody-view", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+  });
+
+  test("createMelodyElements returns element object", () => {
+    const { createMelodyElements } = require("./index");
+    const { createTime } = require("@music-analyzer/time-and");
+
+    const controllers = {
+      gravity: { addListeners: jest.fn() },
+      audio: { addListeners: jest.fn() },
+      d_melody: { addListeners: jest.fn() },
+      window: { addListeners: jest.fn() },
+      time_range: { addListeners: jest.fn() },
+      implication: { addListeners: jest.fn() },
+      melody_beep: { addListeners: jest.fn() },
+      melody_color: { addListeners: jest.fn() },
+      hierarchy: { addListeners: jest.fn() },
+    };
+
+    const melody = {
+      time: createTime(0, 1),
+      head: createTime(0, 0.5),
+      note: 60,
+      melody_analysis: {},
+    };
+
+    const result = createMelodyElements([[melody]], [melody], controllers);
+    expect(result.children.length).toBeGreaterThan(0);
   });
 });

--- a/packages/UI/spectrogram/index.test.ts
+++ b/packages/UI/spectrogram/index.test.ts
@@ -1,0 +1,32 @@
+import { JSDOM } from "jsdom";
+
+describe("spectrogram module", () => {
+  let dom: JSDOM;
+  beforeAll(() => {
+    dom = new JSDOM("<!DOCTYPE html><svg></svg>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+
+    class MockAudioNode { connect() {} }
+    class MockAnalyserNode extends MockAudioNode {
+      fftSize = 1024;
+      getByteTimeDomainData() { return new Uint8Array(1024); }
+      getFloatFrequencyData() { return new Float32Array(1024); }
+    }
+    class MockAudioContext {
+      destination = new MockAudioNode();
+      createMediaElementSource() { return new MockAudioNode(); }
+      createAnalyser() { return new MockAnalyserNode(); }
+    }
+    (global as any).AudioContext = MockAudioContext;
+  });
+
+  test("AudioViewer can be instantiated", () => {
+    const { AudioViewer } = require("./index");
+    const audio = { addEventListener: jest.fn() } as any;
+    const registry = { addListeners: jest.fn() };
+    const viewer = new AudioViewer(audio, registry);
+    expect(viewer).toBeTruthy();
+    expect(() => viewer.onAudioUpdate()).not.toThrow();
+  });
+});

--- a/packages/UI/synth/index.test.ts
+++ b/packages/UI/synth/index.test.ts
@@ -1,7 +1,49 @@
-import * as Module from "./index";
+import { JSDOM } from "jsdom";
 
 describe("synth module", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  beforeAll(() => {
+    const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+    (global as any).window = dom.window as unknown as Window;
+    (global as any).document = dom.window.document;
+
+    class MockAudioNode {
+      connect() {}
+    }
+
+    class MockGainNode extends MockAudioNode {
+      gain = { value: 0, cancelScheduledValues: jest.fn(), linearRampToValueAtTime: jest.fn(), exponentialRampToValueAtTime: jest.fn() };
+    }
+
+    class MockOscillatorNode extends MockAudioNode {
+      type: OscillatorType = "sine";
+      frequency = { value: 0 };
+      detune = { value: 0 };
+      start() {}
+      stop() {}
+    }
+
+    class MockAudioContext {
+      destination = new MockGainNode();
+      currentTime = 0;
+      createGain() { return new MockGainNode(); }
+      createOscillator() { return new MockOscillatorNode(); }
+    }
+
+    (global as any).AudioContext = MockAudioContext;
+  });
+
+  test("factory functions operate without error", () => {
+    const { createGain, createOscillator, play, play_note } = require("./index");
+    const ctx = new AudioContext();
+    const parent = ctx.destination;
+
+    const g = createGain(ctx, parent, 0.5);
+    expect(g.gain.value).toBe(0.5);
+
+    const o = createOscillator(ctx, parent, "square", 440, 0);
+    expect(o.frequency.value).toBe(440);
+
+    expect(() => play([440], 0, 0.1)).not.toThrow();
+    expect(() => play_note([440], 60, 4)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- expand synth tests to mock WebAudio and exercise factory helpers
- instantiate BeatElements/ChordElements/MelodyElements in piano roll tests
- add a test for the spectrogram AudioViewer
- depend on jsdom typings

## Testing
- `yarn test` *(fails: TypeScript errors and missing browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68423c99eb9483328920b7f3f6e3d4f2