### PR TITLE
Refactor beat view to factory pattern

### DIFF
--- a/packages/UI/piano-roll/beat-view/index.ts
+++ b/packages/UI/piano-roll/beat-view/index.ts
@@ -1,2 +1,5 @@
-export { BeatElements } from "./src/beat-elements";
-export { RequiredByBeatElements } from "./src/beat-elements";
+export {
+  createBeatElements,
+  BeatElements,
+  RequiredByBeatElements,
+} from "./src/beat-elements";

--- a/packages/UI/piano-roll/beat-view/src/beat-elements.ts
+++ b/packages/UI/piano-roll/beat-view/src/beat-elements.ts
@@ -1,153 +1,168 @@
 import { BeatInfo } from "@music-analyzer/beat-estimation";
 import { Time, createTime } from "@music-analyzer/time-and";
-import { AudioReflectableRegistry, PianoRollTranslateX, WindowReflectableRegistry } from "@music-analyzer/view";
+import {
+  AudioReflectableRegistry,
+  PianoRollTranslateX,
+  WindowReflectableRegistry,
+} from "@music-analyzer/view";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { NowAt, PianoRollConverter } from "@music-analyzer/view-parameters";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { reservation_range } from "@music-analyzer/view-parameters";
 import { play } from "@music-analyzer/synth";
 
-export class BeatBarModel {
-  readonly time: Time;
-  constructor(beat_info: BeatInfo, i: number) {
-    this.time = createTime(
-      i * 60 / beat_info.tempo,
-      (i + 1) * 60 / beat_info.tempo
-    );
-  }
+export interface BeatBarModel {
+  readonly time: Time
 }
 
-export class BeatBarView {
-  constructor(
-    readonly svg: SVGLineElement,
-  ) { }
-  updateX(x1: number, x2: number) {
-    this.svg.setAttribute("x1", String(x1));
-    this.svg.setAttribute("x2", String(x2));
-  }
-  updateY(y1: number, y2: number) {
-    this.svg.setAttribute("y1", String(y1));
-    this.svg.setAttribute("y2", String(y2));
-  }
+const createBeatBarModel = (beat_info: BeatInfo, i: number): BeatBarModel => ({
+  time: createTime(
+    (i * 60) / beat_info.tempo,
+    ((i + 1) * 60) / beat_info.tempo,
+  ),
+})
+
+export interface BeatBarView {
+  readonly svg: SVGLineElement
 }
 
-export class BeatBar {
-  get svg() { return this.view.svg; }
-  #y1: number;
-  #y2: number;
-  sound_reserved: boolean;
-  constructor(
-    readonly model: BeatBarModel,
-    readonly view: BeatBarView,
-  ) {
-    this.model = model;
-    this.view = view;
-    this.sound_reserved = false;
-    this.#y1 = 0;
-    this.#y2 = PianoRollHeight.get();
-    this.updateX();
-    this.updateY();
-  }
-  updateX() {
-    this.view.updateX(
-      PianoRollConverter.scaled(this.model.time.begin),
-      PianoRollConverter.scaled(this.model.time.begin),
-    )
-  }
-  updateY() {
-    this.view.updateY(
-      this.#y1,
-      this.#y2,
-    )
-  }
-  onWindowResized() {
-    this.updateX();
-  }
-  onTimeRangeChanged = this.onWindowResized
+const updateX_BeatBarView = (svg: SVGLineElement) => (x1: number, x2: number) => {
+  svg.setAttribute("x1", String(x1))
+  svg.setAttribute("x2", String(x2))
+}
 
-  beepBeat() {
+const updateY_BeatBarView = (svg: SVGLineElement) => (y1: number, y2: number) => {
+  svg.setAttribute("y1", String(y1))
+  svg.setAttribute("y2", String(y2))
+}
+
+const createBeatBarView = (svg: SVGLineElement): BeatBarView => ({ svg })
+
+export interface BeatBar {
+  readonly model: BeatBarModel
+  readonly view: BeatBarView
+  readonly onWindowResized: () => void
+  readonly onTimeRangeChanged: () => void
+  readonly onAudioUpdate: () => void
+}
+
+const updateX = (svg: SVGLineElement) => (model: BeatBarModel) => {
+  updateX_BeatBarView(svg)(
+    PianoRollConverter.scaled(model.time.begin),
+    PianoRollConverter.scaled(model.time.begin),
+  )
+}
+
+const updateY = (svg: SVGLineElement) => (y1: number, y2: number) => {
+  updateY_BeatBarView(svg)(y1, y2)
+}
+
+const createBeatBar = (beat_info: BeatInfo, i: number): BeatBar => {
+  const model = createBeatBarModel(beat_info, i)
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "line")
+  svg.id = "bar"
+  svg.style.stroke = "rgb(0, 0, 0)"
+  svg.style.display = "none" // NOTE: 一旦非表示
+  const view = createBeatBarView(svg)
+
+  let sound_reserved = false
+  const y1 = 0
+  const y2 = PianoRollHeight.get()
+  updateX(svg)(model)
+  updateY(svg)(y1, y2)
+
+  const beepBeat = () => {
     const model_is_in_range = createTime(0, reservation_range)
-      .map(e => e + NowAt.get())
-      .has(this.model.time.begin);
+      .map((e) => e + NowAt.get())
+      .has(model.time.begin)
     if (model_is_in_range) {
-      if (this.sound_reserved === false) {
-        play([220], this.model.time.begin - NowAt.get(), 0.125);
-        this.sound_reserved = true;
-        setTimeout(() => { this.sound_reserved = false; }, reservation_range * 1000);
+      if (sound_reserved === false) {
+        play([220], model.time.begin - NowAt.get(), 0.125)
+        sound_reserved = true
+        setTimeout(() => {
+          sound_reserved = false
+        }, reservation_range * 1000)
       }
     }
   }
-  onAudioUpdate() {
-    // NOTE: うるさいので停止中
-    0 && this.beepBeat();
+
+  const onWindowResized = () => {
+    updateX(svg)(model)
   }
+  const onTimeRangeChanged = onWindowResized
+  const onAudioUpdate = () => {
+    // NOTE: うるさいので停止中
+    0 && beepBeat()
+  }
+
+  return { model, view, onWindowResized, onTimeRangeChanged, onAudioUpdate }
 }
 
 export interface RequiredByBeatBarsSeries {
-  readonly audio: AudioReflectableRegistry,
-  readonly window: WindowReflectableRegistry,
-  readonly time_range: TimeRangeController,
+  readonly audio: AudioReflectableRegistry
+  readonly window: WindowReflectableRegistry
+  readonly time_range: TimeRangeController
 }
 
-export class BeatBarsSeries {
-  readonly children_model: { readonly time: Time }[];
-  #show: BeatBar[];
-  get show() { return this.#show; };
-  readonly svg: SVGGElement;
+export interface BeatBarsSeries {
+  readonly children: BeatBar[]
+  readonly svg: SVGGElement
+  readonly children_model: { readonly time: Time }[]
+  readonly show: BeatBar[]
+  readonly onAudioUpdate: () => void
+}
 
-  constructor(
-    readonly children: BeatBar[]
-  ) {
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "g");
-    svg.id = "beat-bars";
-    children.forEach(e => svg.appendChild(e.svg));
+const createBeatBarsSeries = (children: BeatBar[]): BeatBarsSeries => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "g")
+  svg.id = "beat-bars"
+  children.forEach((e) => svg.appendChild(e.view.svg))
 
-    this.svg = svg;
-    this.children_model = children.map(e => e.model);
-    this.#show = children;
+  const onAudioUpdate = () => {
+    svg.setAttribute("transform", `translate(${PianoRollTranslateX.get()})`)
   }
-  onAudioUpdate() { this.svg.setAttribute("transform", `translate(${PianoRollTranslateX.get()})`); }
+
+  return {
+    children,
+    svg,
+    children_model: children.map((e) => e.model),
+    show: children,
+    onAudioUpdate,
+  }
 }
 
 export interface RequiredByBeatElements {
-  readonly audio: AudioReflectableRegistry,
-  readonly window: WindowReflectableRegistry,
-  readonly time_range: TimeRangeController,
+  readonly audio: AudioReflectableRegistry
+  readonly window: WindowReflectableRegistry
+  readonly time_range: TimeRangeController
 }
 
-export class BeatElements {
-  readonly children: BeatBarsSeries[];
-  readonly beat_bars: SVGGElement;
-  constructor(
-    beat_info: BeatInfo,
-    melodies: { time: Time }[],
-    controllers: RequiredByBeatElements
-  ) {
-    const N = Math.ceil(beat_info.tempo * melodies[melodies.length - 1].time.end) + beat_info.phase;
-    const seed = [...Array(N)];
+export interface BeatElements {
+  readonly children: BeatBarsSeries[]
+  readonly beat_bars: SVGGElement
+}
 
-    const beat_bar = seed.map((_, i) => {
-      const model = new BeatBarModel(beat_info, i);
+export const createBeatElements = (
+  beat_info: BeatInfo,
+  melodies: { time: Time }[],
+  controllers: RequiredByBeatElements,
+): BeatElements => {
+  const N = Math.ceil(
+    beat_info.tempo * melodies[melodies.length - 1].time.end,
+  ) + beat_info.phase
+  const seed = [...Array(N)]
 
-      const svg = document.createElementNS("http://www.w3.org/2000/svg", "line");
-      svg.id = "bar";
-      svg.style.stroke = "rgb(0, 0, 0)";
-      svg.style.display = "none";  //NOTE: 一旦非表示にしている
+  const beat_bar = seed.map((_, i) => createBeatBar(beat_info, i))
 
-      const view = new BeatBarView(svg);
-      return new BeatBar(model, view)
-    })
+  const beat_bars = createBeatBarsSeries(beat_bar)
+  controllers.audio.addListeners(
+    ...beat_bars.children.map((e) => e.onAudioUpdate),
+  )
+  controllers.window.addListeners(
+    ...beat_bars.children.map((e) => e.onWindowResized),
+  )
+  controllers.time_range.addListeners(
+    ...beat_bars.children.map((e) => e.onTimeRangeChanged),
+  )
 
-    const beat_bars = new BeatBarsSeries(beat_bar);
-    beat_bars.children
-      .map(e => e.onAudioUpdate.bind(e))
-      .map(f => controllers.audio.addListeners(f))
-    beat_bars.children
-      .map(e => e.onWindowResized.bind(e))
-      .map(f => controllers.window.addListeners(f))
-    const listeners = beat_bars.children.map(e => e.onTimeRangeChanged.bind(e))
-    controllers.time_range.addListeners(...listeners)
-    this.beat_bars = beat_bars.svg
-    this.children = [beat_bars];
-  }
+  return { children: [beat_bars], beat_bars: beat_bars.svg }
 }

--- a/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
+++ b/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
@@ -1,5 +1,5 @@
 import { BeatInfo } from "@music-analyzer/beat-estimation";
-import { BeatElements } from "@music-analyzer/beat-view";
+import { BeatElements, createBeatElements } from "@music-analyzer/beat-view";
 import { SerializedTimeAndRomanAnalysis } from "@music-analyzer/chord-analyze";
 import { ChordElements } from "@music-analyzer/chord-view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
@@ -20,7 +20,7 @@ export class MusicStructureElements {
     d_melodies: SerializedTimeAndAnalyzedMelody[],
     controllers: RequiredByBeatElements & RequiredByChordElements & RequiredByMelodyElements
   ) {
-    this.beat = new BeatElements(beat_info, melodies, controllers)
+    this.beat = createBeatElements(beat_info, melodies, controllers)
     this.chord = new ChordElements(romans, controllers)
     this.melody = createMelodyElements(hierarchical_melody, d_melodies, controllers)
   }


### PR DESCRIPTION
## Summary
- replace BeatBar* and BeatElements classes with factory-based implementations
- export the new factory creator from beat-view
- update analysis-view to use `createBeatElements`

## Testing
- `yarn test` *(fails: AudioContext not defined and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68423c40536c83328fd8b0bda79f2b03