### PR TITLE
Refactor spectrogram components to factories

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -1,7 +1,7 @@
 import { setCurrentTimeRatio, setPianoRollParameters } from "@music-analyzer/view-parameters";
 import { song_list } from "@music-analyzer/gttm";
 import { createAnalyzedDataContainer } from "@music-analyzer/analyzed-data-container";
-import { AudioViewer } from "@music-analyzer/spectrogram";
+import { createAudioViewer } from "@music-analyzer/spectrogram";
 import { PianoRoll } from "@music-analyzer/piano-roll";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { PianoRollWidth } from "@music-analyzer/view-parameters";
@@ -325,7 +325,7 @@ const setupUI = (
   piano_roll_place: HTMLDivElement,
   manager: ApplicationManager,
 ) => {
-  const audio_viewer = new AudioViewer(audio_player, manager.audio_time_mediator);
+  const audio_viewer = createAudioViewer(audio_player, manager.audio_time_mediator);
   const piano_roll_view = new PianoRoll(manager.analyzed, manager.window_size_mediator, !manager.FULL_VIEW)
   asParent(piano_roll_place)
     .appendChildren(

--- a/jest-preload.js
+++ b/jest-preload.js
@@ -7,3 +7,40 @@ global.console = {
   warn: jest.fn(),
   // error: jest.fn(),
 };
+
+class MockAudioNode {
+  connect() {}
+}
+
+class MockGainNode extends MockAudioNode {
+  constructor() {
+    super();
+    this.gain = { value: 0 };
+  }
+}
+
+class MockAnalyserNode extends MockAudioNode {
+  constructor() {
+    super();
+    this.fftSize = 0;
+  }
+  getByteTimeDomainData() {}
+  getFloatTimeDomainData() {}
+  getByteFrequencyData() {}
+  getFloatFrequencyData() {}
+}
+
+class MockMediaElementAudioSourceNode extends MockAudioNode {}
+
+global.AudioContext = class {
+  constructor() {
+    this.destination = new MockAudioNode();
+    this.state = 'running';
+    this.currentTime = 0;
+  }
+  createGain() { return new MockGainNode(); }
+  createOscillator() { return { connect() {}, start() {}, stop() {}, frequency: {}, detune: {} }; }
+  createMediaElementSource() { return new MockMediaElementAudioSourceNode(); }
+  createAnalyser() { return new MockAnalyserNode(); }
+  resume() {}
+};

--- a/packages/UI/spectrogram/index.test.ts
+++ b/packages/UI/spectrogram/index.test.ts
@@ -1,0 +1,7 @@
+import * as Module from "./index";
+
+describe("spectrogram module", () => {
+  test("should load module", () => {
+    expect(Module).toBeTruthy();
+  });
+});

--- a/packages/UI/spectrogram/index.ts
+++ b/packages/UI/spectrogram/index.ts
@@ -1,1 +1,11 @@
-export { AudioViewer } from "./src/audio-viewer";
+export {
+  type AudioViewer,
+  createAudioViewer,
+} from "./src/audio-viewer";
+export {
+  type AudioAnalyzer,
+  createAudioAnalyzer,
+} from "./src/audio-analyzer";
+export { type FFTViewer, createFFTViewer } from "./src/fft-viewer";
+export { type SpectrogramViewer, createSpectrogramViewer } from "./src/spectrogram-viewer";
+export { type WaveViewer, createWaveViewer } from "./src/wave-viewer";

--- a/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/audio-analyzer.ts
@@ -7,24 +7,33 @@ import { getFFT } from "./get-fft";
 
 const resumeAudioCtx = (audioCtx: AudioContext) => () => { audioCtx.state === 'suspended' && audioCtx.resume(); }
 
-export class AudioAnalyzer {
-  private readonly audioCtx: AudioContext;
-  private readonly source: MediaElementAudioSourceNode;
+export interface AudioAnalyzer {
   readonly analyser: AnalyserNode;
-
-  constructor(audioElement: HTMLAudioElement) {
-    this.audioCtx = new AudioContext();
-    this.source = this.audioCtx.createMediaElementSource(audioElement);
-    this.analyser = this.audioCtx.createAnalyser();
-
-    audioElement.addEventListener("play", resumeAudioCtx(this.audioCtx));
-    this.analyser.fftSize = 1024;
-    connect(this.source, this.analyser, this.audioCtx.destination);
-  }
-
-  getByteTimeDomainData() { return getByteTimeDomainData(this.analyser); }
-  getFloatTimeDomainData() { return getFloatTimeDomainData(this.analyser); }
-  getByteFrequencyData() { return getByteFrequencyData(this.analyser); }
-  getFloatFrequencyData() { return getFloatFrequencyData(this.analyser); }
-  getFFT() { return getFFT(this.analyser); }
+  getByteTimeDomainData(): Uint8Array;
+  getFloatTimeDomainData(): Float32Array;
+  getByteFrequencyData(): Uint8Array;
+  getFloatFrequencyData(): Float32Array;
+  getFFT(): [Float32Array, Float32Array];
 }
+
+export const createAudioAnalyzer = (
+  audioElement: HTMLAudioElement,
+  contextFactory: () => AudioContext = () => new AudioContext(),
+): AudioAnalyzer => {
+  const audioCtx = contextFactory();
+  const source = audioCtx.createMediaElementSource(audioElement);
+  const analyser = audioCtx.createAnalyser();
+
+  audioElement.addEventListener("play", resumeAudioCtx(audioCtx));
+  analyser.fftSize = 1024;
+  connect(source, analyser, audioCtx.destination);
+
+  return {
+    analyser,
+    getByteTimeDomainData: () => getByteTimeDomainData(analyser),
+    getFloatTimeDomainData: () => getFloatTimeDomainData(analyser),
+    getByteFrequencyData: () => getByteFrequencyData(analyser),
+    getFloatFrequencyData: () => getFloatFrequencyData(analyser),
+    getFFT: () => getFFT(analyser),
+  };
+};

--- a/packages/UI/spectrogram/src/audio-analyzer/index.ts
+++ b/packages/UI/spectrogram/src/audio-analyzer/index.ts
@@ -1,1 +1,4 @@
-export { AudioAnalyzer } from "./audio-analyzer";
+export {
+  type AudioAnalyzer,
+  createAudioAnalyzer,
+} from "./audio-analyzer";

--- a/packages/UI/spectrogram/src/audio-viewer.ts
+++ b/packages/UI/spectrogram/src/audio-viewer.ts
@@ -1,28 +1,30 @@
 import { AudioReflectableRegistry } from "@music-analyzer/view";
-import { WaveViewer } from "./wave-viewer";
-import { spectrogramViewer } from "./spectrogram-viewer";
-import { AudioAnalyzer } from "./audio-analyzer";
-import { FFTViewer } from "./fft-viewer";
+import { WaveViewer, createWaveViewer } from "./wave-viewer";
+import { SpectrogramViewer, createSpectrogramViewer } from "./spectrogram-viewer";
+import { AudioAnalyzer, createAudioAnalyzer } from "./audio-analyzer";
+import { FFTViewer, createFFTViewer } from "./fft-viewer";
 
 // AudioAnalyzer.ts
-export class AudioViewer {
+export interface AudioViewer {
   readonly wave: WaveViewer;
-  readonly spectrogram: spectrogramViewer;
+  readonly spectrogram: SpectrogramViewer;
   readonly fft: FFTViewer;
-
-  constructor(
-    private readonly audio_element: HTMLMediaElement,
-    audio_registry: AudioReflectableRegistry
-  ) {
-    const analyser = new AudioAnalyzer(this.audio_element);
-    this.wave = new WaveViewer(analyser);
-    this.spectrogram = new spectrogramViewer(analyser);
-    this.fft = new FFTViewer(analyser)
-    audio_registry.addListeners(this.onAudioUpdate.bind(this));
-  }
-  onAudioUpdate() {
-    this.wave.onAudioUpdate();
-    this.spectrogram.onAudioUpdate();
-    this.fft.onAudioUpdate();
-  }
+  onAudioUpdate(): void;
 }
+
+export const createAudioViewer = (
+  audio_element: HTMLMediaElement,
+  audio_registry: AudioReflectableRegistry,
+): AudioViewer => {
+  const analyser = createAudioAnalyzer(audio_element);
+  const wave = createWaveViewer(analyser);
+  const spectrogram = createSpectrogramViewer(analyser);
+  const fft = createFFTViewer(analyser);
+  const onAudioUpdate = () => {
+    wave.onAudioUpdate();
+    spectrogram.onAudioUpdate();
+    fft.onAudioUpdate();
+  };
+  audio_registry.addListeners(onAudioUpdate);
+  return { wave, spectrogram, fft, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/fft-viewer.ts
+++ b/packages/UI/spectrogram/src/fft-viewer.ts
@@ -1,54 +1,41 @@
-import { Complex } from "@music-analyzer/math";
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class FFTViewer {
-  private readonly path: SVGPathElement;
+export interface FFTViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "rgb(192,0,255)");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "fft";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
-
-  onAudioUpdate() {
-    const freqData = this.analyser.getFFT();
-    const N = freqData[0].length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
-    let pathData = "";
-
-    const abs = <T extends number>(e: Complex<T>) => Math.sqrt(e.re * e.re + e.im * e.im)
-    const absV = (...c: [Float32Array<ArrayBuffer>, Float32Array<ArrayBuffer>]) =>
-      c[0].map((e, i) => Math.sqrt(e * e + c[1][i] * c[1][i]))
-
-    this.path.setAttribute("d", "M" +
-//      freqData.map(e => abs(e))
-        [...Array.from(absV(...freqData))]
-        .map((e, i) => {
-          if (isNaN(e * 0)) { return ``; }
-          const x = i / (N - 1) * width;
-          const y = (1 - Math.log2(1+e)) * height;
-//          const y = (1 - Math.log2(1 + e) / 8) * height;
-          return `L ${x},${y}`;
-        })
-        .join()
-        .slice(1))
-
-    /*
-    for (let i = 0; i < N; i++) {
-      if (isNaN(freqData[i].re * 0)) { continue; }
-      const x = i / (N - 1) * width;
-      const y = (1 - Math.log2(1 + abs(freqData[i])) / 8) * height;
-      pathData += `L ${x},${y}`;
-    }
-    this.path.setAttribute("d", "M" + pathData.slice(1));
-    */
-  }
+  onAudioUpdate(): void;
 }
+
+export const createFFTViewer = (analyser: AudioAnalyzer): FFTViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "rgb(192,0,255)");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "fft";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFFT();
+    const N = freqData[0].length / 2;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
+    const absV = (...c: [Float32Array, Float32Array]) =>
+      c[0].map((e, i) => Math.sqrt(e * e + c[1][i] * c[1][i]));
+    path.setAttribute(
+      "d",
+      "M" +
+        [...Array.from(absV(...freqData))]
+          .map((e, i) => {
+            if (isNaN(e * 0)) return "";
+            const x = (i / (N - 1)) * width;
+            const y = (1 - Math.log2(1 + e)) * height;
+            return `L ${x},${y}`;
+          })
+          .join()
+          .slice(1),
+    );
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/spectrogram-viewer.ts
+++ b/packages/UI/spectrogram/src/spectrogram-viewer.ts
@@ -1,37 +1,35 @@
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class spectrogramViewer {
-  private readonly path: SVGPathElement;
+export interface SpectrogramViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "red");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "spectrum";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-  }
+  onAudioUpdate(): void;
+}
 
-  onAudioUpdate() {
-    const freqData = this.analyser.getFloatFrequencyData();
+export const createSpectrogramViewer = (analyser: AudioAnalyzer): SpectrogramViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "red");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "spectrum";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+
+  const onAudioUpdate = () => {
+    const freqData = analyser.getFloatFrequencyData();
     const fftSize = freqData.length / 2;
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let pathData = "";
-
     for (let i = 0; i < fftSize; i++) {
-      if (isNaN(freqData[i] * 0)) { continue; }
-      const x = i / (fftSize - 1) * width;
+      if (isNaN(freqData[i] * 0)) continue;
+      const x = (i / (fftSize - 1)) * width;
       const y = -(freqData[i] / 128) * height;
       pathData += `L ${x},${y}`;
     }
-    [pathData]
-      .map(e => e.slice(1))
-      .filter(e => e.length > 0)
-      .map(e => this.path.setAttribute("d", "M" + e))
-  }
-}
+    const d = pathData.slice(1);
+    if (d.length > 0) path.setAttribute("d", "M" + d);
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/spectrogram/src/wave-viewer.ts
+++ b/packages/UI/spectrogram/src/wave-viewer.ts
@@ -1,57 +1,50 @@
-import { Complex } from "@music-analyzer/math";
-import { correlation } from "@music-analyzer/math";
+import { Complex, correlation } from "@music-analyzer/math";
 import { AudioAnalyzer } from "./audio-analyzer";
 
-export class WaveViewer {
-  private readonly path: SVGPathElement;
-  private old_wave: Complex<number>[];
+export interface WaveViewer {
   readonly svg: SVGSVGElement;
-  constructor(
-    private readonly analyser: AudioAnalyzer,
-  ) {
-    this.path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    this.path.setAttribute("stroke", "blue");
-    this.path.setAttribute("fill", "none");
-    this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this.svg.appendChild(this.path);
-    this.svg.id = "sound-wave";
-    this.svg.setAttribute("width", String(800));
-    this.svg.setAttribute("height", String(450));
-    this.old_wave = [... new Array(analyser.analyser.fftSize)].map(e => new Complex(0, 0));
-  }
+  onAudioUpdate(): void;
+}
 
-  private getDelay(copy:Complex<number>[]){
-    const col = correlation(this.old_wave, copy);
+export const createWaveViewer = (analyser: AudioAnalyzer): WaveViewer => {
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("stroke", "blue");
+  path.setAttribute("fill", "none");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.appendChild(path);
+  svg.id = "sound-wave";
+  svg.setAttribute("width", String(800));
+  svg.setAttribute("height", String(450));
+  const old_wave = Array.from({ length: analyser.analyser.fftSize }, () => new Complex(0, 0));
 
+  const getDelay = (copy: Complex<number>[]) => {
+    const col = correlation(old_wave, copy);
     let delay = 0;
     for (let i = 0; i < col.length / 2; i++) {
-      if (col[delay].re < col[i].re) {
-        delay = i;
-      }
+      if (col[delay].re < col[i].re) delay = i;
     }
     for (let i = 0; i < copy.length; i++) {
-      this.old_wave[i] = copy[(i + delay) % copy.length];
+      old_wave[i] = copy[(i + delay) % copy.length];
     }
-    return delay;    
-  }
+    return delay;
+  };
 
-  onAudioUpdate() {
-    const wave = this.analyser.getByteTimeDomainData();
-    const width = this.svg.clientWidth;
-    const height = this.svg.clientHeight;
+  const onAudioUpdate = () => {
+    const wave = analyser.getByteTimeDomainData();
+    const width = svg.clientWidth;
+    const height = svg.clientHeight;
     let path_data = "";
-
     const copy: Complex<number>[] = [];
-    wave.forEach(e => { copy.push(new Complex(e, 0)); });
-    const delay = this.getDelay(copy);
-
+    wave.forEach(e => copy.push(new Complex(e, 0)));
+    const delay = getDelay(copy);
     for (let i = 0; i < wave.length / 2; i++) {
-      if (isNaN(wave[i + delay] * 0)) { continue; }
-      const x = i * 2 / (wave.length - 1) * width;
-      // データは [0,255] なので, 中心を height/2 として正規化
-      const y = wave[i + delay] / 255 * height;
+      if (isNaN(wave[i + delay] * 0)) continue;
+      const x = (i * 2) / (wave.length - 1) * width;
+      const y = (wave[i + delay] / 255) * height;
       path_data += `L ${x},${y}`;
     }
-    this.path.setAttribute("d", "M" + path_data.slice(1));
-  }
-}
+    path.setAttribute("d", "M" + path_data.slice(1));
+  };
+
+  return { svg, onAudioUpdate };
+};

--- a/packages/UI/view-parameters/index.test.ts
+++ b/packages/UI/view-parameters/index.test.ts
@@ -1,0 +1,7 @@
+import * as Module from "./index";
+
+describe("view-parameters module", () => {
+  test("should load module", () => {
+    expect(Module).toBeTruthy();
+  });
+});

--- a/packages/UI/view-parameters/index.ts
+++ b/packages/UI/view-parameters/index.ts
@@ -4,41 +4,37 @@ export const size = 2;
 export const octave_height = size * 84;  // 7 白鍵と 12 半音をきれいに描画するには 7 * 12 の倍数が良い
 export const black_key_height = octave_height / 12;
 
-export class NowAt {
-  constructor(readonly value: number) { }
+export interface NowAt { get(): number; set(value: number): void; }
+export const createNowAt = (initial = 0): NowAt => {
+  let val = initial;
+  return { get: () => val, set: (v: number) => { val = v; } };
+};
+export const NowAt = createNowAt();
 
-  static #value = 0;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
+export interface PianoRollRatio { get(): number; set(value: number): void; }
+export const createPianoRollRatio = (initial = 1): PianoRollRatio => {
+  let val = initial;
+  return { get: () => val, set: (v: number) => { val = v; } };
+};
+export const PianoRollRatio = createPianoRollRatio();
 
-export class PianoRollRatio {
-  constructor(readonly value: number) { }
+interface PianoRollTimeLength { _get(): number }
+const createPianoRollTimeLength = (
+  ratio: PianoRollRatio,
+  length: SongLength,
+): PianoRollTimeLength => ({ _get: () => ratio.get() * length.get() });
+const PianoRollTimeLength = {
+  get: () => PianoRollRatio.get() * SongLength.get(),
+};
 
-  static #value: number = 1;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-
-class PianoRollTimeLength {
-  constructor(
-    private readonly ratio: PianoRollRatio,
-    private readonly length: SongLength,
-  ) { }
-  _get() { return this.ratio.value * this.length.value }
-
-  static get() { return PianoRollRatio.get() * SongLength.get(); }
-}
-
-export class NoteSize {
-  constructor(
-    private readonly width: PianoRollWidth,
-    private readonly length: PianoRollTimeLength,
-  ) { }
-  _get() { return this.width._get() / this.length._get(); }
-
-  static get() { return PianoRollWidth.get() / PianoRollTimeLength.get(); }
-}
+export interface NoteSize { _get(): number }
+export const createNoteSize = (
+  width: PianoRollWidth,
+  length: PianoRollTimeLength,
+): NoteSize => ({ _get: () => width._get() / length._get() });
+export const NoteSize = {
+  get: () => PianoRollWidth.get() / PianoRollTimeLength.get(),
+};
 
 const transposed = (e: number) => e - PianoRollBegin.get();
 const scaled = (e: number) => e * NoteSize.get();
@@ -65,72 +61,72 @@ export const PianoRollConverter = {
   convertToCoordinate,
 } as const;
 
-class CurrentTimeRatio {
-  constructor(readonly value: number) { };
+interface CurrentTimeRatio { get(): number; set(value: number): void; }
+const createCurrentTimeRatio = (initial = 1 / 4): CurrentTimeRatio => {
+  let val = initial;
+  return { get: () => val, set: (v: number) => { val = v; } };
+};
+const CurrentTimeRatio = createCurrentTimeRatio();
 
-  static #value = 1 / 4;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-
-export class CurrentTimeX {
-  constructor(
-    private readonly width: PianoRollWidth,
-    private readonly ratio: CurrentTimeRatio,
-  ) { }
-  _get() { return this.width._get() * this.ratio.value; }
-
-  static get() {
-    return PianoRollWidth.get() * CurrentTimeRatio.get();
-  }
-}
-export class OctaveCount {
-  constructor(
-    private readonly end: PianoRollEnd,
-    private readonly begin: PianoRollBegin,
-  ) { }
-  _get() { return Math.ceil(-(this.end.value - this.begin.value) / 12); }
-
-  static get() { return Math.ceil(-(PianoRollEnd.get() - PianoRollBegin.get()) / 12); }
-}
-export class PianoRollBegin {
-  constructor(readonly value: number) { }
-
-  static #value = 83;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-export class PianoRollEnd {
-  constructor(readonly value: number) { }
-
-  static #value = 83 + 24;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
-export class PianoRollHeight {
-  constructor(
-    private readonly count: OctaveCount
-  ) { }
-  _get() { return octave_height * this.count._get(); }
-
-  static get() { return octave_height * OctaveCount.get(); }
-}
+export interface CurrentTimeX { _get(): number }
+export const createCurrentTimeX = (
+  width: PianoRollWidth,
+  ratio: CurrentTimeRatio,
+): CurrentTimeX => ({ _get: () => width._get() * ratio.get() });
+export const CurrentTimeX = {
+  get: () => PianoRollWidth.get() * CurrentTimeRatio.get(),
+};
+export interface OctaveCount { _get(): number }
+export const createOctaveCount = (
+  end: PianoRollEnd,
+  begin: PianoRollBegin,
+): OctaveCount => ({ _get: () => Math.ceil(-(end.value - begin.value) / 12) });
+export const OctaveCount = {
+  get: () => Math.ceil(-(PianoRollEnd.get() - PianoRollBegin.get()) / 12),
+};
+export interface PianoRollBegin { value: number }
+export const createPianoRollBegin = (initial = 83): PianoRollBegin => {
+  return { value: initial };
+};
+let pianoRollBeginValue = 83;
+export const PianoRollBegin = {
+  get: () => pianoRollBeginValue,
+  set: (v: number) => { pianoRollBeginValue = v; },
+};
+export interface PianoRollEnd { value: number }
+export const createPianoRollEnd = (initial = 83 + 24): PianoRollEnd => {
+  return { value: initial };
+};
+let pianoRollEndValue = 83 + 24;
+export const PianoRollEnd = {
+  get: () => pianoRollEndValue,
+  set: (v: number) => { pianoRollEndValue = v; },
+};
+export interface PianoRollHeight { _get(): number }
+export const createPianoRollHeight = (count: OctaveCount): PianoRollHeight => ({
+  _get: () => octave_height * count._get(),
+});
+export const PianoRollHeight = {
+  get: () => octave_height * OctaveCount.get(),
+};
 class WindowInnerWidth {
   _get() { return window.innerWidth; }
   static get() { return window.innerWidth; }
 }
 
-export class PianoRollWidth {
-  _get() { return window.innerWidth - 48; }
-  static get() { return WindowInnerWidth.get() - 48; }
-}
-class SongLength {
-  constructor(readonly value: number) { }
-
-  static #value: number = 0;
-  static get() { return this.#value; }
-  static set(value: number) { this.#value = value; }
-}
+export interface PianoRollWidth { _get(): number }
+export const createPianoRollWidth = (): PianoRollWidth => ({
+  _get: () => window.innerWidth - 48,
+});
+export const PianoRollWidth = {
+  get: () => WindowInnerWidth.get() - 48,
+};
+interface SongLength { get(): number; set(value: number): void; }
+const createSongLength = (initial = 0): SongLength => {
+  let val = initial;
+  return { get: () => val, set: (v: number) => { val = v; } };
+};
+const SongLength = createSongLength();
 
 export const setCurrentTimeRatio = (e: number) => { CurrentTimeRatio.set(e) }
 


### PR DESCRIPTION
## Summary
- refactor spectrogram classes to interfaces with factory creators
- convert view-parameter wrappers to interface-based singletons
- add jest AudioContext mocks
- update html analyze import
- add minimal module tests

## Testing
- `yarn test` *(fails: ReferenceError document is not defined and other TypeScript errors)*
- `yarn build` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68423c58e10083328c2f930202e97cac