### PR TITLE
Fix controllers tsconfig

### DIFF
--- a/packages/UI/controllers/tsconfig.json
+++ b/packages/UI/controllers/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "types": ["jest"],
+    "types": [],
     "declaration": true,
     "sourceMap": true,
     "outDir": "**/dist"


### PR DESCRIPTION
## Summary
- remove jest types from controllers `tsconfig.json`

## Testing
- `npx tsc -p packages/UI/controllers/tsconfig.json` *(fails: Cannot find module '@music-analyzer/irm' or its corresponding type declarations)*
- `npx jest packages/UI/piano-roll/melody-view/index.test.ts` *(fails: needed to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6842a54e739483329b01561aaf6b9a53