### PR TITLE
Fix switcher controller interfaces

### DIFF
--- a/packages/UI/controllers/index.ts
+++ b/packages/UI/controllers/index.ts
@@ -1,6 +1,6 @@
 export { SetColor } from "./src/color-selector";
 export { MelodyColorController, createMelodyColorController } from "./src/color-selector";
-export { ControllerView } from "./src/controller";
+export type { ControllerView } from "./src/controller";
 export type { MelodyBeepVolume, MelodyBeepSwitcher, MelodyBeepController } from "./src/melody-beep-controller";
 export {
   createMelodyBeepVolume,
@@ -15,7 +15,7 @@ export {
   HierarchyLevelController,
   TimeRangeController,
 } from "./src/slider";
-export { Controller } from "./src/controller";
+export type { Controller } from "./src/controller";
 export {
   createCheckbox,
   Checkbox,

--- a/packages/UI/controllers/src/color-selector.ts
+++ b/packages/UI/controllers/src/color-selector.ts
@@ -5,7 +5,7 @@ import { get_color_on_digital_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_intervallic_angle } from "@music-analyzer/irm";
 import { get_color_on_parametric_scale } from "@music-analyzer/irm";
 import { get_color_on_registral_scale } from "@music-analyzer/irm";
-import { Controller, createController } from "./controller";
+import { createControllerView } from "./controller";
 
 
 export type GetColor = (e: ITriad) => string;
@@ -32,73 +32,72 @@ export interface MelodyColorController {
   addListeners(...listeners: ((color: GetColor) => void)[]): void;
 }
 
-class ColorSelectorImpl<T> extends Controller<T> implements ColorSelector<T> {
-  constructor(id: string, text: string) {
-    super("radio", id, text);
-  }
-  update() { /* noop */ }
-}
+const createColorSelector = <T>(
+  id: string,
+  text: string,
+  onUpdate: (listeners: ((e: T) => void)[], input: HTMLInputElement) => void,
+): ColorSelector<T> => {
+  const { body, input } = createControllerView("radio", id, text);
+  const listeners: ((e: T) => void)[] = [];
+  const update = () => onUpdate(listeners, input);
+  input.addEventListener("input", update);
+  update();
+  return {
+    body,
+    input,
+    addListeners: (...ls: ((e: T) => void)[]) => {
+      listeners.push(...ls);
+      update();
+    },
+  };
+};
 
-class IRM_ColorSelectorImpl
-  extends ColorSelectorImpl<GetColor>
-  implements IRM_ColorSelector {
-  constructor(
-    id: string,
-    text: string,
-    readonly getColor: GetColor,
-  ) {
-    super(id, text);
-  }
-  override update() {
-    this.listeners.forEach(setColor => setColor(triad => this.getColor(triad)));
-  }
-}
+const createIRMColorSelector = (
+  id: string,
+  text: string,
+  getColor: GetColor,
+): IRM_ColorSelector => {
+  const selector = createColorSelector<GetColor>(id, text, (ls, _input) => {
+    ls.forEach(setColor => setColor(triad => getColor(triad)));
+  });
+  return { ...selector, getColor };
+};
 
-class MelodyColorSelectorImpl implements MelodyColorSelector {
-  readonly body: HTMLDivElement;
-  readonly children: IRM_ColorSelectorImpl[];
-  readonly default: IRM_ColorSelectorImpl;
-  constructor() {
-    this.children = [
-      new IRM_ColorSelectorImpl("Narmour_concept", "Narmour concept color", get_color_of_Narmour_concept),
-      new IRM_ColorSelectorImpl("implication_realization", "implication realization", get_color_of_implication_realization),
-      new IRM_ColorSelectorImpl("digital_parametric_scale", "digital parametric scale color", get_color_on_digital_parametric_scale),
-      new IRM_ColorSelectorImpl("digital_intervallic_scale", "digital intervallic scale color", get_color_on_digital_intervallic_scale),
-      new IRM_ColorSelectorImpl("registral_scale", "registral scale color", get_color_on_registral_scale),
-      new IRM_ColorSelectorImpl("intervallic_angle", "intervallic angle color", get_color_on_intervallic_angle),
-      new IRM_ColorSelectorImpl("analog_parametric_scale", "analog parametric scale color", get_color_on_parametric_scale),
-    ];
-    this.children.forEach(e => { e.input.name = "melody-color-selector"; });
+const createMelodyColorSelector = (): MelodyColorSelector => {
+  const children: IRM_ColorSelector[] = [
+    createIRMColorSelector("Narmour_concept", "Narmour concept color", get_color_of_Narmour_concept),
+    createIRMColorSelector("implication_realization", "implication realization", get_color_of_implication_realization),
+    createIRMColorSelector("digital_parametric_scale", "digital parametric scale color", get_color_on_digital_parametric_scale),
+    createIRMColorSelector("digital_intervallic_scale", "digital intervallic scale color", get_color_on_digital_intervallic_scale),
+    createIRMColorSelector("registral_scale", "registral scale color", get_color_on_registral_scale),
+    createIRMColorSelector("intervallic_angle", "intervallic angle color", get_color_on_intervallic_angle),
+    createIRMColorSelector("analog_parametric_scale", "analog parametric scale color", get_color_on_parametric_scale),
+  ];
+  children.forEach(e => { e.input.name = "melody-color-selector"; });
 
-    this.default = this.children[0];
-    this.default && (this.default.input.checked = true);
+  const body = document.createElement("div");
+  body.id = "melody_color_selector";
+  children.forEach(e => body.appendChild(e.body));
+  if (children[0]) children[0].input.checked = true;
 
-    this.body = document.createElement("div");
-    this.body.id = "melody_color_selector";
-    this.children.forEach(e => this.body.appendChild(e.body));
-    this.default.update();
-  }
-  addListeners(...listeners: ((color: GetColor) => void)[]) {
-    this.children.forEach(e => e.addListeners(...listeners));
-    this.default.update();
-  }
-}
+  return {
+    body,
+    addListeners: (...listeners: ((color: GetColor) => void)[]) => {
+      children.forEach(c => c.addListeners(...listeners));
+    },
+  };
+};
 
-class MelodyColorControllerImpl implements MelodyColorController {
-  readonly view: HTMLDivElement;
-  readonly selector: MelodyColorSelectorImpl;
-  constructor() {
-    this.selector = new MelodyColorSelectorImpl();
-    this.view = document.createElement("div");
-    this.view.id = "melody-color-selector";
-    this.view.style.display = "inline";
-    this.view.appendChild(this.selector.body);
-  }
-  addListeners(...listeners: ((color: GetColor) => void)[]) {
-    this.selector.addListeners(...listeners);
-  }
-}
-
-export const createMelodyColorController = (): MelodyColorController =>
-  new MelodyColorControllerImpl();
+export const createMelodyColorController = (): MelodyColorController => {
+  const selector = createMelodyColorSelector();
+  const view = document.createElement("div");
+  view.id = "melody-color-selector";
+  view.style.display = "inline";
+  view.appendChild(selector.body);
+  return {
+    view,
+    selector,
+    addListeners: (...ls: ((color: GetColor) => void)[]) => selector.addListeners(...ls),
+  };
+};
 

--- a/packages/UI/controllers/src/slider.ts
+++ b/packages/UI/controllers/src/slider.ts
@@ -1,5 +1,5 @@
 import { PianoRollRatio } from "@music-analyzer/view-parameters";
-import { ControllerView } from "./controller";
+import { createControllerView } from "./controller";
 
 export interface Slider<T> {
   readonly body: HTMLSpanElement;
@@ -19,7 +19,7 @@ export const createSlider = <T>(ops: {
   updateDisplay(input: HTMLInputElement, display: HTMLSpanElement): void;
   getValue(input: HTMLInputElement): T;
 }): Slider<T> => {
-  const view = new ControllerView("range", ops.id, ops.label);
+  const view = createControllerView("range", ops.id, ops.label);
   const { body, input } = view;
   const display = document.createElement("span");
   body.appendChild(display);

--- a/packages/UI/controllers/src/switcher.ts
+++ b/packages/UI/controllers/src/switcher.ts
@@ -1,4 +1,4 @@
-import { Controller, createController } from "./controller";
+import { createControllerView } from "./controller";
 
 export interface Checkbox {
   readonly body: HTMLSpanElement
@@ -7,16 +7,22 @@ export interface Checkbox {
 }
 
 export const createCheckbox = (id: string, label: string): Checkbox => {
-  class CheckboxImpl extends Controller<boolean> {
-    constructor() {
-      super("checkbox", id, label)
-      this.input.checked = false
-    }
-    update() {
-      this.listeners.forEach(e => e(this.input.checked))
-    }
+  const { body, input } = createControllerView("checkbox", id, label)
+  input.checked = false
+  const listeners: ((e: boolean) => void)[] = []
+  const update = () => {
+    listeners.forEach(e => e(input.checked))
   }
-  return new CheckboxImpl()
+  input.addEventListener("input", update)
+  update()
+  return {
+    body,
+    input,
+    addListeners: (...ls: ((e: boolean) => void)[]) => {
+      listeners.push(...ls)
+      update()
+    },
+  }
 }
 
 export interface DMelodyController {


### PR DESCRIPTION
## Summary
- remove class-based controllers for checkboxes and melody color pickers
- use `createControllerView` factory in slider
- type-only exports for controller interfaces

## Testing
- `yarn workspace @music-analyzer/controllers build`
- `yarn test` *(fails: ChordProgression only refers to a type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842a54a77b08332972b696a01ccb27e