### PR TITLE
Configure jsdom test environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  // Use jsdom so DOM APIs are available in tests that manipulate HTML
+  testEnvironment: 'jsdom',
   transform: {
   },
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^9.21.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
     "jsdom": "^26.1.0",
     "madge": "^8.0.0",
     "ts-jest": "^29.2.6",


### PR DESCRIPTION
## Summary
- use `jsdom` environment in Jest so DOM APIs are available
- install `jest-environment-jsdom`

## Testing
- `yarn build` *(fails: `@music-analyzer/chord-analyze#build` exited with code 1)*
- `yarn test` *(fails: several TypeScript errors)*
- `npx jest packages/util/html/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6842a96e28608332bbf792d0a63523a0