### PR TITLE
Fix CLI tests with temporary paths

### DIFF
--- a/packages/cli/post-crepe/index.test.ts
+++ b/packages/cli/post-crepe/index.test.ts
@@ -1,7 +1,14 @@
-import * as Module from "./index";
+import fs from "fs";
+import path from "path";
 
 describe("post-crepe module", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  test("should execute with temporary paths", () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, "tmp-"));
+    const csvPath = path.join(__dirname, "vocals.csv");
+    const originalArgv = process.argv;
+    process.argv = ["node", "index.ts", csvPath, tmpDir];
+    jest.resetModules();
+    expect(() => require("./index")).not.toThrow();
+    process.argv = originalArgv;
   });
 });

--- a/packages/cli/post-pyin/index.test.ts
+++ b/packages/cli/post-pyin/index.test.ts
@@ -1,7 +1,14 @@
-import * as Module from "./index";
+import fs from "fs";
+import path from "path";
 
 describe("post-pyin module", () => {
-  test("should load module", () => {
-    expect(Module).toBeTruthy();
+  test("should execute with temporary paths", () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, "tmp-"));
+    const jsonPath = path.join(__dirname, "out.json");
+    const originalArgv = process.argv;
+    process.argv = ["node", "index.ts", jsonPath, tmpDir];
+    jest.resetModules();
+    expect(() => require("./index")).not.toThrow();
+    process.argv = originalArgv;
   });
 });


### PR DESCRIPTION
## Summary
- provide temporary file paths to post-crepe and post-pyin tests

## Testing
- `yarn build` *(fails: @music-analyzer/chord-analyze build exited with error)*
- `yarn test` *(fails to run several test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6842a97068bc8332828b3c036090ca10