### PR TITLE
Fix compress test object comparison

### DIFF
--- a/packages/util/time-and/index.test.ts
+++ b/packages/util/time-and/index.test.ts
@@ -19,9 +19,13 @@ describe("Time class", () => {
 describe("compress", () => {
   test("groups consecutive items", () => {
     const result = compress(["a", "a", "b", "b", "b"]);
-    expect(result).toEqual([
-      { time: createTime(0, 2), item: "a" },
-      { time: createTime(2, 5), item: "b" },
+    const mapped = result.map(({ time, item }) => ({
+      time: { begin: time.begin, end: time.end },
+      item,
+    }));
+    expect(mapped).toEqual([
+      { time: { begin: 0, end: 2 }, item: "a" },
+      { time: { begin: 2, end: 5 }, item: "b" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- update `compress` test to compare range properties instead of whole `Time` objects

## Testing
- `yarn build` *(fails: command not found or build errors)*
- `yarn test` *(fails: multiple TypeScript errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842a973798883328a538b1d3f791b94