### PR TITLE
Refactor melody color selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ const audioReg = createAudioReflectableRegistry();
 const windowReg = createWindowReflectableRegistry();
 ```
 
+Color selector controllers are now created via factories as well:
+
+```ts
+import { createMelodyColorController } from "@music-analyzer/controllers";
+const colorCtrl = createMelodyColorController();
+```
+
 Time ranges and FFT helpers follow the same pattern:
 
 ```ts

--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -28,7 +28,7 @@ import { DMelodyController } from "@music-analyzer/controllers";
 import { GravityController } from "@music-analyzer/controllers";
 import { HierarchyLevelController } from "@music-analyzer/controllers";
 import { MelodyBeepController } from "@music-analyzer/controllers";
-import { MelodyColorController } from "@music-analyzer/controllers";
+import { MelodyColorController, createMelodyColorController } from "@music-analyzer/controllers";
 import { TimeRangeController } from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
 import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
@@ -58,7 +58,7 @@ class Controllers {
     this.implication = new ImplicationDisplayController();
     this.gravity = new GravityController(gravity_visible);
     this.melody_beep = new MelodyBeepController();
-    this.melody_color = new MelodyColorController();
+    this.melody_color = createMelodyColorController();
     this.melody_beep.checkbox.input.checked=true;
     this.implication.prospective_checkbox.input.checked = false;
     this.implication.retrospective_checkbox.input.checked = true;


### PR DESCRIPTION
## Summary
- switch MelodyColorController instantiation to factory API
- document color selector controller factory in README

## Testing
- `yarn build` *(fails: @music-analyzer/chord-analyze#build)*
- `yarn test` *(fails to compile multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6842a8b105a08332b469a54cd11d5c97