### PR TITLE
Resolve controller factory imports

### DIFF
--- a/html/analyze/index.ts
+++ b/html/analyze/index.ts
@@ -2,7 +2,7 @@ import { setCurrentTimeRatio, setPianoRollParameters } from "@music-analyzer/vie
 import { song_list } from "@music-analyzer/gttm";
 import { createAnalyzedDataContainer } from "@music-analyzer/analyzed-data-container";
 import { createAudioViewer } from "@music-analyzer/spectrogram";
-import { PianoRoll } from "@music-analyzer/piano-roll";
+import { createPianoRoll, PianoRoll } from "@music-analyzer/piano-roll";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { PianoRollWidth } from "@music-analyzer/view-parameters";
 import { GTTMData } from "@music-analyzer/gttm";
@@ -21,17 +21,26 @@ import { SerializedMelodyAnalysisData } from "@music-analyzer/melody-analyze";
 import { xml_parser } from "@music-analyzer/serializable-data";
 import { AudioReflectableRegistry, createAudioReflectableRegistry } from "@music-analyzer/view";
 import { NowAt } from "@music-analyzer/view-parameters";
-import { MusicStructureElements } from "@music-analyzer/piano-roll";
+import { createMusicStructureElements, MusicStructureElements } from "@music-analyzer/piano-roll";
 import { WindowReflectableRegistry, createWindowReflectableRegistry } from "@music-analyzer/view";
 import { BeatInfo } from "@music-analyzer/beat-estimation";
-import { DMelodyController } from "@music-analyzer/controllers";
-import { GravityController } from "@music-analyzer/controllers";
-import { HierarchyLevelController } from "@music-analyzer/controllers";
-import { MelodyBeepController } from "@music-analyzer/controllers";
-import { MelodyColorController } from "@music-analyzer/controllers";
-import { TimeRangeController } from "@music-analyzer/controllers";
+import {
+  DMelodyController,
+  createDMelodyController,
+  GravityController,
+  createGravityController,
+  HierarchyLevelController,
+  createHierarchyLevelController,
+  MelodyBeepController,
+  createMelodyBeepController,
+  MelodyColorController,
+  createMelodyColorController,
+  TimeRangeController,
+  createTimeRangeController,
+  ImplicationDisplayController,
+  createImplicationDisplayController,
+} from "@music-analyzer/controllers";
 import { Time } from "@music-analyzer/time-and";
-import { ImplicationDisplayController } from "@music-analyzer/controllers/src/switcher";
 
 class Controllers {
   readonly div: HTMLDivElement
@@ -52,13 +61,13 @@ class Controllers {
     this.div.id = "controllers";
     this.div.style = "margin-top:20px";
 
-    this.d_melody = new DMelodyController();
-    this.hierarchy = new HierarchyLevelController(layer_count);
-    this.time_range = new TimeRangeController(length);
-    this.implication = new ImplicationDisplayController();
-    this.gravity = new GravityController(gravity_visible);
-    this.melody_beep = new MelodyBeepController();
-    this.melody_color = new MelodyColorController();
+    this.d_melody = createDMelodyController();
+    this.hierarchy = createHierarchyLevelController(layer_count);
+    this.time_range = createTimeRangeController(length);
+    this.implication = createImplicationDisplayController();
+    this.gravity = createGravityController(gravity_visible);
+    this.melody_beep = createMelodyBeepController();
+    this.melody_color = createMelodyColorController();
     this.melody_beep.checkbox.input.checked=true;
     this.implication.prospective_checkbox.input.checked = false;
     this.implication.retrospective_checkbox.input.checked = true;
@@ -135,7 +144,7 @@ class ApplicationManager {
       window: this.window_size_mediator,
     }
 
-    this.analyzed = new MusicStructureElements(beat_info, romans, hierarchical_melody, melodies, d_melodies, controllers)
+    this.analyzed = createMusicStructureElements(beat_info, romans, hierarchical_melody, melodies, d_melodies, controllers)
   }
 }
 
@@ -261,7 +270,7 @@ const setupUI = (
   manager: ApplicationManager,
 ) => {
   const audio_viewer = createAudioViewer(audio_player, manager.audio_time_mediator);
-  const piano_roll_view = new PianoRoll(manager.analyzed, manager.window_size_mediator, !manager.FULL_VIEW);
+  const piano_roll_view = createPianoRoll(manager.analyzed, manager.window_size_mediator, !manager.FULL_VIEW);
   asParent(piano_roll_place)
     .appendChildren(
       /*

--- a/jest-preload.js
+++ b/jest-preload.js
@@ -8,6 +8,10 @@ global.console = {
   // error: jest.fn(),
 };
 
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
 class MockAudioNode {
   connect() {}
 }

--- a/packages/UI/piano-roll/melody-view/index.test.ts
+++ b/packages/UI/piano-roll/melody-view/index.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from "jsdom";
 
 function expectFn(name: string) {
-  expect(typeof (Module as any)[name]).toBe("function");
+  expect(typeof require("./index")[name]).toBe("function");
 }
 
 describe("piano-roll melody-view", () => {

--- a/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
+++ b/packages/UI/piano-roll/piano-roll/src/analysis-view.ts
@@ -1,9 +1,12 @@
 import { BeatInfo } from "@music-analyzer/beat-estimation";
-import { BeatElements, createBeatElements } from "@music-analyzer/beat-view";
+import { createBeatElements } from "@music-analyzer/beat-view";
+import type { BeatElements } from "@music-analyzer/beat-view";
 import { SerializedTimeAndRomanAnalysis } from "@music-analyzer/chord-analyze";
-import { ChordElements, createChordElements } from "@music-analyzer/chord-view";
+import { createChordElements } from "@music-analyzer/chord-view";
+import type { ChordElements } from "@music-analyzer/chord-view";
 import { SerializedTimeAndAnalyzedMelody } from "@music-analyzer/melody-analyze";
-import { MelodyElements, createMelodyElements } from "@music-analyzer/melody-view";
+import { createMelodyElements } from "@music-analyzer/melody-view";
+import type { MelodyElements } from "@music-analyzer/melody-view";
 import { RequiredByBeatElements } from "@music-analyzer/beat-view";
 import { RequiredByChordElements } from "@music-analyzer/chord-view";
 import { RequiredByMelodyElements } from "@music-analyzer/melody-view";
@@ -22,8 +25,8 @@ export function createMusicStructureElements(
   d_melodies: SerializedTimeAndAnalyzedMelody[],
   controllers: RequiredByBeatElements & RequiredByChordElements & RequiredByMelodyElements,
 ): MusicStructureElements {
-  const beat = new BeatElements(beat_info, melodies, controllers)
-  const chord = new ChordElements(romans, controllers)
+  const beat = createBeatElements(beat_info, melodies, controllers)
+  const chord = createChordElements(romans, controllers)
   const melody = createMelodyElements(hierarchical_melody, d_melodies, controllers)
   return { beat, chord, melody }
 }

--- a/packages/UI/spectrogram/src/wave-viewer.ts
+++ b/packages/UI/spectrogram/src/wave-viewer.ts
@@ -1,4 +1,5 @@
-import { Complex, correlation } from "@music-analyzer/math";
+import { createComplex, correlation } from "@music-analyzer/math";
+import type { Complex } from "@music-analyzer/math";
 import { AudioAnalyzer } from "./audio-analyzer";
 
 export interface WaveViewer {
@@ -15,7 +16,7 @@ export const createWaveViewer = (analyser: AudioAnalyzer): WaveViewer => {
   svg.id = "sound-wave";
   svg.setAttribute("width", String(800));
   svg.setAttribute("height", String(450));
-  const old_wave = Array.from({ length: analyser.analyser.fftSize }, () => new Complex(0, 0));
+  const old_wave = Array.from({ length: analyser.analyser.fftSize }, () => createComplex(0, 0));
 
   const getDelay = (copy: Complex<number>[]) => {
     const col = correlation(old_wave, copy);
@@ -35,7 +36,7 @@ export const createWaveViewer = (analyser: AudioAnalyzer): WaveViewer => {
     const height = svg.clientHeight;
     let path_data = "";
     const copy: Complex<number>[] = [];
-    wave.forEach(e => copy.push(new Complex(e, 0)));
+    wave.forEach(e => copy.push(createComplex(e, 0)));
     const delay = getDelay(copy);
     for (let i = 0; i < wave.length / 2; i++) {
       if (isNaN(wave[i + delay] * 0)) continue;

--- a/packages/music-structure/beat/beat-estimation/src/calc-tempo.ts
+++ b/packages/music-structure/beat/beat-estimation/src/calc-tempo.ts
@@ -1,5 +1,6 @@
 import { argmax } from "@music-analyzer/math";
-import { Complex } from "@music-analyzer/math";
+import { createComplex } from "@music-analyzer/math";
+import type { Complex } from "@music-analyzer/math";
 import { correlation } from "@music-analyzer/math";
 import { decimal } from "@music-analyzer/math";
 import { getRange } from "@music-analyzer/math";
@@ -62,7 +63,7 @@ export const calcTempo = (melodies: SerializedTimeAndAnalyzedMelody[], romans: S
   console.log("onsets");
   console.log(onsets);
   */
- const complex_onset = onsets.map(e => new Complex(e, 0));
+ const complex_onset = onsets.map(e => createComplex(e, 0));
   const tps = correlation(
     complex_onset,
     complex_onset,

--- a/packages/music-structure/chord/chord-analyze/src/chord-analyze/index.ts
+++ b/packages/music-structure/chord/chord-analyze/src/chord-analyze/index.ts
@@ -9,4 +9,4 @@ export {
   SerializedTimeAndRomanAnalysis,
   SerializedRomanAnalysisData,
 } from "./serialized-time-and-roman-analysis";
-export { createChordProgression } from "./key-estimation/chord-progression";
+export { createChordProgression } from "../key-estimation/chord-progression";

--- a/packages/music-structure/chord/chord-analyze/src/key-estimation/index.ts
+++ b/packages/music-structure/chord/chord-analyze/src/key-estimation/index.ts
@@ -1,1 +1,1 @@
-export { ChordProgression } from "./chord-progression";
+export { ChordProgression, createChordProgression } from "./chord-progression";

--- a/packages/music-structure/chord/chord-analyze/test/key-estimation.test.ts
+++ b/packages/music-structure/chord/chord-analyze/test/key-estimation.test.ts
@@ -1,5 +1,5 @@
 import { Chord } from "@music-analyzer/tonal-objects/src/chord/chord";
-import { ChordProgression } from "../src/key-estimation/chord-progression";
+import { createChordProgression } from "../src/key-estimation/chord-progression";
 import { getChord } from "../src/key-estimation/get-chord";
 
 const empty_chord: Chord = { aliases: [], bass: "", chroma: "", empty: true, intervals: [], name: "", normalized: "", notes: [], quality: "Unknown", root: "", rootDegree: 0, setNum: NaN, symbol: "", tonic: null, type: "" };
@@ -25,11 +25,11 @@ describe("key estimation module test", () => {
   });
 
   test("Canon progression", () => {
-    const progression = new ChordProgression(["CM7", "G7", "Am7", "Em7", "FM7", "CM7", "FM7", "G7"]);
+    const progression = createChordProgression(["CM7", "G7", "Am7", "Em7", "FM7", "CM7", "FM7", "G7"]);
     const candidate_scales = progression.lead_sheet_chords.map(
-      (e, t) => progression.getStatesOnTime(t)
+      (_: string, t: number) => progression.getStatesOnTime(t)
     );
-    expect(candidate_scales.map(e => e.map(e => e.name))).toEqual(
+    expect(candidate_scales.map(scales => scales.map(s => s.name))).toEqual(
       [
         ["C major", "G major"],            // CM7
         ["C major"],                       // G7
@@ -56,11 +56,11 @@ describe("key estimation module test", () => {
   });
 
   test("progression includes mM7 chord", () => {
-    const progression = new ChordProgression(["GM7", "GmM7", "F#m7", "Bm7", "A7", "DM7"]);
+    const progression = createChordProgression(["GM7", "GmM7", "F#m7", "Bm7", "A7", "DM7"]);
     const candidate_scales = progression.lead_sheet_chords.map(
-      (e, t) => progression.getStatesOnTime(t)
+      (_: string, t: number) => progression.getStatesOnTime(t)
     );
-    expect(candidate_scales.map(e => e.map(e => e.name))).toEqual(
+    expect(candidate_scales.map(scales => scales.map(s => s.name))).toEqual(
       [
         ["D major", "G major"],            // GM7
         [""],                              // GmM7 TODO: fix: ここで候補がなくなってしまう
@@ -85,11 +85,11 @@ describe("key estimation module test", () => {
   });
 
   test("Just the Two of Us Progression", () => {
-    const progression = new ChordProgression(["DbM7", "C7", "Fm7", "Ebm7", "Ab7"]);
+    const progression = createChordProgression(["DbM7", "C7", "Fm7", "Ebm7", "Ab7"]);
     const candidate_scales = progression.lead_sheet_chords.map(
-      (e, t) => progression.getStatesOnTime(t)
+      (_: string, t: number) => progression.getStatesOnTime(t)
     );
-    expect(candidate_scales.map(e => e.map(e => e.name))).toEqual(
+    expect(candidate_scales.map(scales => scales.map(s => s.name))).toEqual(
       [
         ["Db major", "Ab major"],
         ["F major"],

--- a/packages/util/math/index.ts
+++ b/packages/util/math/index.ts
@@ -1,6 +1,6 @@
 export { Compare } from "./src/reduction";
 export { decimal } from "./src/basic-function";
-export { Complex } from "./src/fft";
+export { Complex, createComplex } from "./src/fft";
 export { createRootOfUnity } from "./src/fft";
 export { fft } from "./src/fft";
 export { correlation } from "./src/fft";


### PR DESCRIPTION
## Summary
- fix controller factory imports in analyze index and other packages
- export createComplex and use createComplex in audio and tempo modules
- adjust factory usage in tests and add util TextEncoder polyfill

## Testing
- `yarn build`
- `yarn test` *(fails: TypeError from util/color and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_6842a92723bc8332aad2b008fb7ab34b