### PR TITLE
Refactor melody cache factories

### DIFF
--- a/packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts
+++ b/packages/UI/piano-roll/melody-view/src/ir-plot-svg.ts
@@ -53,75 +53,84 @@ const createIRPlotHierarchyView = (
   updateCircleVisibility: (visible_layer) => circles.setShow(visible_layer),
 });
 
-class CacheCore {
-  #cache: SerializedTimeAndAnalyzedMelody[];
-  #index: number;
-  constructor(
-    readonly melody_series: SerializedTimeAndAnalyzedMelody[],
-  ) {
-    this.#cache = [];
-    this.#index = 0;
-  }
-
-  cacheHit() {
-    return this.#cache[1]?.time.has(NowAt.get());
-  }
-  cacheUpdate() {
-    if (this.cacheHit()) { return this.#cache; }
-    else {
-      this.#index = this.melody_series.findIndex((value) =>
-        value.time.has(NowAt.get())
-      );
-    }
-    const i = this.#index;
-    const N = this.melody_series.length;
-    const melodies = [
-      this.melody_series[Math.max(0, i - 1)],
-      this.melody_series[Math.max(0, i)],
-      this.melody_series[Math.min(i + 1, N - 1)],
-      this.melody_series[Math.min(i + 2, N - 1)],
-    ];
-    this.#cache = melodies;
-  }
-  get index() {
-    this.cacheUpdate();
-    return this.#index;
-  }
-  get melody() {
-    this.cacheUpdate();
-    return this.#cache;
-  }
+interface CacheCore {
+  readonly melody_series: SerializedTimeAndAnalyzedMelody[];
+  readonly index: number;
+  readonly melody: SerializedTimeAndAnalyzedMelody[];
 }
 
-class MelodiesCache {
-  #core: CacheCore;
-  constructor(
-    melody_series: SerializedTimeAndAnalyzedMelody[],
-  ) {
-    this.#core = new CacheCore(melody_series);
-  }
-  get is_visible() {
-    const i = this.#core.index;
-    return 1 <= i && i < this.#core.melody_series.length - 1;
-  }
-  getRangedMelody() { return this.#core.melody; }
-  getPositionRatio() {
-    const melodies = this.#core.melody;
+const createCacheCore = (
+  melodySeries: SerializedTimeAndAnalyzedMelody[],
+): CacheCore => {
+  let cache: SerializedTimeAndAnalyzedMelody[] = [];
+  let index = 0;
+
+  const cacheHit = (): boolean => cache[1]?.time.has(NowAt.get());
+  const cacheUpdate = (): void => {
+    if (cacheHit()) { return; }
+    index = melodySeries.findIndex((value) =>
+      value.time.has(NowAt.get())
+    );
+    const i = index;
+    const N = melodySeries.length;
+    cache = [
+      melodySeries[Math.max(0, i - 1)],
+      melodySeries[Math.max(0, i)],
+      melodySeries[Math.min(i + 1, N - 1)],
+      melodySeries[Math.min(i + 2, N - 1)],
+    ];
+  };
+
+  const core: CacheCore = {
+    melody_series: melodySeries,
+    get index() { cacheUpdate(); return index; },
+    get melody() { cacheUpdate(); return cache; },
+  };
+  return core;
+};
+
+interface MelodiesCache {
+  readonly is_visible: boolean;
+  getRangedMelody: () => SerializedTimeAndAnalyzedMelody[];
+  getPositionRatio: () => number;
+  getInterval: () => number[];
+  getCurrentNote: () => SerializedTimeAndAnalyzedMelody;
+}
+
+const createMelodiesCache = (
+  melodySeries: SerializedTimeAndAnalyzedMelody[],
+): MelodiesCache => {
+  const core = createCacheCore(melodySeries);
+
+  const is_visible = (): boolean => {
+    const i = core.index;
+    return 1 <= i && i < core.melody_series.length - 1;
+  };
+  const getRangedMelody = (): SerializedTimeAndAnalyzedMelody[] => core.melody;
+  const getPositionRatio = (): number => {
+    const melodies = core.melody;
     const t = [melodies[1].time.begin, melodies[2].time.begin];
     return (NowAt.get() - t[0]) / (t[1] - t[0]);
-  }
-  getInterval() {
-    const melodies = this.#core.melody.map(e => e.note);
+  };
+  const getInterval = (): number[] => {
+    const melodies = core.melody.map(e => e.note);
     return [
       melodies[1] - melodies[0] || 0,
       melodies[2] - melodies[1] || 0,
       melodies[3] - melodies[2] || 0,
     ];
-  }
-  getCurrentNote() {
-    return this.#core.melody[1];
-  }
-}
+  };
+  const getCurrentNote = (): SerializedTimeAndAnalyzedMelody => core.melody[1];
+
+  const cache: MelodiesCache = {
+    get is_visible() { return is_visible(); },
+    getRangedMelody: () => getRangedMelody(),
+    getPositionRatio: () => getPositionRatio(),
+    getInterval: () => getInterval(),
+    getCurrentNote: () => getCurrentNote(),
+  };
+  return cache;
+};
 
 interface IRPlotModel {
   readonly time: Time;
@@ -135,7 +144,7 @@ interface IRPlotModel {
   getCurrentNote: () => SerializedTimeAndAnalyzedMelody;
 }
 const createIRPlotModel = (melody_series: SerializedTimeAndAnalyzedMelody[]): IRPlotModel => {
-  const melody = new MelodiesCache(melody_series);
+  const melody = createMelodiesCache(melody_series);
   const model: IRPlotModel = {
     time: createTime(0, 0),
     head: createTime(0, 0),


### PR DESCRIPTION
## Summary
- refactor `CacheCore` and `MelodiesCache` into interface-based factories
- update `IRPlot` model builder to use new factories

## Testing
- `yarn build` *(fails: turbo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad2786188332895b6e2ee148d88f