### PR TITLE
Update GTTMData to factory pattern

### DIFF
--- a/html/analyze/dist/index.global.js
+++ b/html/analyze/dist/index.global.js
@@ -2079,6 +2079,9 @@ Expected id is: ${regexp}`);
       this.prolongation = prolongation;
     }
   };
+  function createGTTMData(grouping, metric, time_span, prolongation) {
+    return { grouping, metric, time_span, prolongation };
+  }
   var song_list = [
     { title: "Error", author: "Error" },
     { title: "Waltz in E flat\u201DGrande Valse Brillante\u201DOp.18", author: "Fr\xE9d\xE9ric Fran\xE7ois Chopin" },
@@ -7750,7 +7753,7 @@ Expected symbol: P, IP, VP, R, IR, VR, D, ID
       roman,
       melody,
       hierarchical_melody,
-      new GTTMData(grouping, metric, time_span, prolongation)
+      createGTTMData(grouping, metric, time_span, prolongation)
     );
   };
   var GTTM_URLs = class {

--- a/html/analyze/dist/index.mjs
+++ b/html/analyze/dist/index.mjs
@@ -6,7 +6,7 @@ import { AudioViewer } from "@music-analyzer/spectrogram";
 import { PianoRoll } from "@music-analyzer/piano-roll";
 import { PianoRollHeight } from "@music-analyzer/view-parameters";
 import { PianoRollWidth } from "@music-analyzer/view-parameters";
-import { GTTMData } from "@music-analyzer/gttm";
+import { createGTTMData } from "@music-analyzer/gttm";
 import { ProlongationalReduction } from "@music-analyzer/gttm";
 import { TimeSpanReduction } from "@music-analyzer/gttm";
 import { getHierarchicalMelody } from "@music-analyzer/melody-hierarchical-analysis";
@@ -385,7 +385,7 @@ var compoundMusicData = (title2) => (e) => {
     roman,
     melody,
     hierarchical_melody,
-    new GTTMData(grouping, metric, time_span, prolongation)
+    createGTTMData(grouping, metric, time_span, prolongation)
   );
 };
 var GTTM_URLs = class {

--- a/packages/cognitive-theory-of-music/gttm/index.ts
+++ b/packages/cognitive-theory-of-music/gttm/index.ts
@@ -5,5 +5,5 @@ export { ITimeSpanReduction } from "./src/analysis-result";
 export { IProlongationalReduction } from "./src/analysis-result";
 export { createTimeSpanReduction, createTimeSpan, TimeSpan } from "./src/analysis-result";
 export { createProlongationalReduction } from "./src/analysis-result";
-export { GTTMData } from "./src/analysis-result";
+export { GTTMData, createGTTMData } from "./src/analysis-result";
 export { song_list } from "./src/sample";

--- a/packages/cognitive-theory-of-music/gttm/src/analysis-result/gttm-data.ts
+++ b/packages/cognitive-theory-of-music/gttm/src/analysis-result/gttm-data.ts
@@ -3,11 +3,21 @@ import { MetricalStructure } from "./MTR";
 import { IProlongationalReduction } from "./PR";
 import { ITimeSpanReduction } from "./TSR";
 
-export class GTTMData {
-  constructor(
-    readonly grouping?: GroupingStructure,
-    readonly metric?: MetricalStructure,
-    readonly time_span?: ITimeSpanReduction,
-    readonly prolongation?: IProlongationalReduction,
-  ) { }
+export interface GTTMData {
+  readonly grouping?: GroupingStructure;
+  readonly metric?: MetricalStructure;
+  readonly time_span?: ITimeSpanReduction;
+  readonly prolongation?: IProlongationalReduction;
 }
+
+export const createGTTMData = (
+  grouping?: GroupingStructure,
+  metric?: MetricalStructure,
+  time_span?: ITimeSpanReduction,
+  prolongation?: IProlongationalReduction,
+): GTTMData => ({
+  grouping,
+  metric,
+  time_span,
+  prolongation,
+});

--- a/packages/cognitive-theory-of-music/gttm/src/analysis-result/index.ts
+++ b/packages/cognitive-theory-of-music/gttm/src/analysis-result/index.ts
@@ -2,7 +2,7 @@ export { Note } from "./common";
 export { ReductionElement, createReductionElement } from "./ReductionElement";
 export { createTimeSpanReduction, createTimeSpan, TimeSpan } from "./TSR";
 export { createProlongationalReduction } from "./PR";
-export { GTTMData } from "./gttm-data";
+export { GTTMData, createGTTMData } from "./gttm-data";
 export { MetricalStructure } from "./MTR";
 export { ITimeSpanReduction } from "./TSR";
 export { IProlongationalReduction } from "./PR";


### PR DESCRIPTION
## Summary
- convert `GTTMData` class to an interface and provide a `createGTTMData` factory
- export new factory from gttm package
- use the factory in prebuilt analyze bundle

## Testing
- `yarn build` *(fails: Could not resolve "./key-estimation/chord-progression")*
- `yarn test` *(fails to compile various TypeScript tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad2b527883328389997d34c3d797