### PR TITLE
Add helper for melody IR objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ import { createRootOfUnity } from "@music-analyzer/math";
 const time = createTime(0, 1);
 const roots = createRootOfUnity();
 ```
+
+A helper for working with analyzed melody data now follows the same pattern:
+
+```ts
+import { createSerializedTimeAndAnalyzedMelodyAndIR } from "@music-analyzer/melody-hierarchical-analysis";
+const entry = createSerializedTimeAndAnalyzedMelodyAndIR(melody, "I");
+```

--- a/packages/music-structure/melody/melody-hierarchical-analysis/index.ts
+++ b/packages/music-structure/melody/melody-hierarchical-analysis/index.ts
@@ -35,22 +35,27 @@ export const getTimeAndMelody = (
   );
 };
 
-class SerializedTimeAndAnalyzedMelodyAndIR
+export interface SerializedTimeAndAnalyzedMelodyAndIR
   extends SerializedTimeAndAnalyzedMelody {
-  constructor(
-    e: SerializedTimeAndAnalyzedMelody,
-    readonly IR: string,
-  ) {
-    super(e.time, e.head, e.note, e.melody_analysis);
-  }
+  readonly IR: string;
 }
 
-const appendIR = (e: SerializedTimeAndAnalyzedMelody) => {
-  return new SerializedTimeAndAnalyzedMelodyAndIR(
+export const createSerializedTimeAndAnalyzedMelodyAndIR = (
+  e: SerializedTimeAndAnalyzedMelody,
+  IR: string,
+): SerializedTimeAndAnalyzedMelodyAndIR => ({
+  time: e.time,
+  head: e.head,
+  note: e.note,
+  melody_analysis: e.melody_analysis,
+  IR,
+});
+
+const appendIR = (e: SerializedTimeAndAnalyzedMelody) =>
+  createSerializedTimeAndAnalyzedMelodyAndIR(
     e,
     e.melody_analysis.implication_realization.symbol,
   );
-};
 
 const analyzeAndScaleMelody = (measure: number, matrix: TimeSpan[][], musicxml: MusicXML) => (element: ReductionElement) => {
   const w = measure / 8;  // NOTE: 1 measure = 3.5


### PR DESCRIPTION
## Summary
- add `SerializedTimeAndAnalyzedMelodyAndIR` interface and factory function
- update hierarchical melody analysis to use factory
- document the helper in the README

## Testing
- `yarn build` *(fails: turbo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad2cb1e48332a8c70d7304766086