### PR TITLE
Fix uncontrolled command line in post-pyin

### DIFF
--- a/ServerProgram/index.ts
+++ b/ServerProgram/index.ts
@@ -4,7 +4,7 @@ import { Request } from "express";
 import { Response } from "express";
 import { dirname } from "path";
 import { basename } from "path";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 
 import { default as multer } from "multer";
 import { default as express } from "express";
@@ -393,7 +393,7 @@ const semitonesBy_pYIN = (
   }
   else if (detectFile(e.src)) {
     makeNewDir(e.dst_dir);
-    execSync(`node ./packages/cli/post-pyin "${e.src}" "${e.dst_dir}"`)
+    execFileSync("node", ["./packages/cli/post-pyin", e.src, e.dst_dir])
   }
   else {
     console.log(`required file ${e.src} not exist`)


### PR DESCRIPTION
## Summary
- use `execFileSync` for the post-pyin CLI invocation

## Testing
- `yarn build` *(fails: turbo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b64f6de4833288a23a4331ce70b6