### PR TITLE
Fix uncontrolled command line in melody analysis

### DIFF
--- a/ServerProgram/index.ts
+++ b/ServerProgram/index.ts
@@ -4,7 +4,7 @@ import { Request } from "express";
 import { Response } from "express";
 import { dirname } from "path";
 import { basename } from "path";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 
 import { default as multer } from "multer";
 import { default as express } from "express";
@@ -329,7 +329,20 @@ const melodyAnalysisByCrepe = (
     const has_chord_src = detectFile(chord_src);
     if (has_midi_src && has_chord_src) {
       makeNewDir(e.dst_dir);
-      execSync(`node ./packages/melody-analyze-cli -m "${e.src}" -r "${chord_src}" -o "${e.dst}" --sampling_rate 100`)
+      execFileSync(
+        "node",
+        [
+          "./packages/melody-analyze-cli",
+          "-m",
+          e.src,
+          "-r",
+          chord_src,
+          "-o",
+          e.dst,
+          "--sampling_rate",
+          "100",
+        ],
+      );
     }
     else if (false === has_chord_src) {
       console.log(`required file ${chord_src} not exist`)
@@ -354,7 +367,20 @@ const melodyAnalysisBy_pYIN = (
   else if (detectFile(e.src) && detectFile(chord_src)) {
     const sr = 22050 / 1024;
     makeNewDir(e.dst_dir);
-    execSync(`node ./packages/melody-analyze-cli -m "${e.src}" -r "${chord_src}" -o "${e.dst}" --sampling_rate ${sr}`)
+    execFileSync(
+      "node",
+      [
+        "./packages/melody-analyze-cli",
+        "-m",
+        e.src,
+        "-r",
+        chord_src,
+        "-o",
+        e.dst,
+        "--sampling_rate",
+        `${sr}`,
+      ],
+    );
   }
   else {
     console.log(`required file ${e.src} not exist`)


### PR DESCRIPTION
## Summary
- use `execFileSync` with argument array for melody analysis CLI

## Testing
- `yarn build` *(fails: turbo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b68b05008332a344c8c926d9acd2