### PR TITLE
Fix shell command injection risk

### DIFF
--- a/ServerProgram/index.ts
+++ b/ServerProgram/index.ts
@@ -4,7 +4,7 @@ import { Request } from "express";
 import { Response } from "express";
 import { dirname } from "path";
 import { basename } from "path";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 
 import { default as multer } from "multer";
 import { default as express } from "express";
@@ -374,7 +374,7 @@ const semitonesByCrepe = (
   }
   else if (detectFile(e.src)) {
     makeNewDir(e.dst_dir);
-    execSync(`./sh/callPostCrepe.sh "${song_name}"`);
+    spawnSync("sh", ["./sh/callPostCrepe.sh", song_name], { stdio: "inherit" });
   }
   else {
     console.log(`required file ${e.src} not exist`)


### PR DESCRIPTION
## Summary
- use `spawnSync` instead of `execSync` for running `callPostCrepe.sh`

## Testing
- `yarn build`
- `yarn test` *(fails: Invalid Record Length and multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842b668a14c83329da72d022bc13236