### PR TITLE
Fix makeNewDir exists check

### DIFF
--- a/ServerProgram/index.ts
+++ b/ServerProgram/index.ts
@@ -2,7 +2,6 @@ import { chmodSync, existsSync, mkdirSync, readdir, renameSync, rmdirSync } from
 import { NextFunction } from "express";
 import { Request } from "express";
 import { Response } from "express";
-import { dirname } from "path";
 import { basename } from "path";
 import { execSync } from "child_process";
 
@@ -115,10 +114,10 @@ const detectFile = (dst: string) => {
   return exists;
 };
 
- const makeNewDir = (
+const makeNewDir = (
   dst_dir: string
 ) => {
-  if (decodeURI(dirname(dst_dir))) { return; }
+  if (existsSync(decodeURI(dst_dir))) return;
   mkdirSync(decodeURI(dst_dir));
   chmodSync(decodeURI(dst_dir), 0o775);
 };


### PR DESCRIPTION
## Summary
- remove unused `dirname` import
- check directory existence with `existsSync`

## Testing
- `yarn build` *(fails: turbo not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b54169a08332adf80a1b753bd5b7