### PR TITLE
Add README docs for UI packages

### DIFF
--- a/docs/update_log.md
+++ b/docs/update_log.md
@@ -1,0 +1,5 @@
+# Update Log
+
+## 2024-06-10
+- Added README files for UI packages (`controllers`, `piano-roll`, `spectrogram`, `synth`, `view`, `view-parameters`).
+- Created this log and a work log to help future contributors.

--- a/docs/work_log.md
+++ b/docs/work_log.md
@@ -1,0 +1,6 @@
+# Work Log
+
+2024-06-10
+- Wrote new README files for each package under `packages/UI`.
+- Created `docs/update_log.md` with a summary of the changes.
+- Recorded this work log for future contributors.

--- a/packages/UI/controllers/README.md
+++ b/packages/UI/controllers/README.md
@@ -1,0 +1,13 @@
+# UI Controllers
+
+This package contains reusable classes that create common form controls for the web UI.
+
+## Main classes
+
+- **Controller** and **ControllerView**: base implementation for controls that wrap an HTML input and notify listeners on value changes.
+- **Slider**: `Controller` for range inputs. Used by `HierarchyLevelController` and `TimeRangeController` to select melody layer and time range.
+- **Checkbox**: simple on/off switch used by many controllers such as `DMelodyController` and `GravityController`.
+- **MelodyColorController**: group of radio buttons that chooses how melody notes are colored.
+- **MelodyBeepController**: checkbox and volume slider allowing playback of short beep sounds.
+
+These small components can be combined to build interactive views.

--- a/packages/UI/piano-roll/README.md
+++ b/packages/UI/piano-roll/README.md
@@ -1,0 +1,10 @@
+# Piano Roll Views
+
+This directory provides components used to render a piano roll interface.
+
+- **beat-view** draws beat bars so that playback timing can be followed.
+- **chord-view** shows chord names and brackets above the roll.
+- **melody-view** paints melody notes at multiple hierarchy levels.
+- **piano-roll** combines the above elements and manages background graphics.
+
+Each submodule exposes small view classes that can be assembled into the application UI.

--- a/packages/UI/spectrogram/README.md
+++ b/packages/UI/spectrogram/README.md
@@ -1,0 +1,11 @@
+# Spectrogram Components
+
+This package visualizes audio data using the Web Audio API.
+
+- **AudioViewer** connects an `HTMLMediaElement` with three viewers: `WaveViewer`,
+  `spectrogramViewer`, and `FFTViewer`.
+- **wave-viewer.ts** draws the waveform of the current audio buffer.
+- **spectrogram-viewer.ts** renders a scrolling frequency spectrogram.
+- **fft-viewer.ts** shows the instantaneous FFT result.
+
+These viewers update in real time when the audio registry notifies them of new data.

--- a/packages/UI/synth/README.md
+++ b/packages/UI/synth/README.md
@@ -1,0 +1,9 @@
+# Synth Utilities
+
+Utility functions that wrap the Web Audio API for quick sound playback.
+
+- **createGain** and **createOscillator** create basic audio nodes.
+- **play** plays arbitrary tones with ADSR envelope settings.
+- **play_note** is a helper to play notes based on BPM and note value.
+
+These helpers are used by the UI when short confirmation sounds are needed.

--- a/packages/UI/view-parameters/README.md
+++ b/packages/UI/view-parameters/README.md
@@ -1,0 +1,9 @@
+# View Parameters
+
+This module defines shared constants and helper classes used to calculate sizes and coordinates for the UI. Examples include:
+
+- `PianoRollConverter` for converting MIDI note numbers to screen coordinates.
+- Classes like `CurrentTimeX`, `PianoRollWidth`, and `NoteSize` that compute layout values on demand.
+- Utility setters such as `setPianoRollParameters` which configure the piano roll based on analyzed melody data.
+
+All visualization packages depend on these parameters to stay in sync with window size and song length.

--- a/packages/UI/view/README.md
+++ b/packages/UI/view/README.md
@@ -1,0 +1,8 @@
+# View Utilities
+
+This package provides small helper classes used by different UI components.
+
+- **AudioReflectableRegistry** and **WindowReflectableRegistry** work as simple event registries. Components subscribe to them to receive audio or window update notifications.
+- **PianoRollTranslateX** calculates the horizontal offset so that the current time remains centered when the window size changes.
+
+These utilities are shared across the piano roll and spectrogram modules.


### PR DESCRIPTION
## Summary
- document controller components
- describe piano-roll modules
- outline spectrogram utilities
- explain synth helpers
- add docs for view and view-parameter packages
- create update and work logs

## Testing
- `yarn test --silent` *(fails: jest not found)*
- `yarn lint --silent` *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6843aa069cdc8332b2313fde0b0e9ba5