### PR TITLE
Add module READMEs and update log

### DIFF
--- a/docs/update_log.md
+++ b/docs/update_log.md
@@ -1,0 +1,5 @@
+# Update Log
+## 2025-06-07
+- Added README files for gttm, irm and tonal-pitch-space describing main purpose and key modules.
+- Documented core data structures and algorithms used.
+- Created `docs/update_log.md` to record future updates.

--- a/docs/work_log.md
+++ b/docs/work_log.md
@@ -1,0 +1,5 @@
+# Work Log
+## 2025-06-07
+- Created README for each theory module: gttm, irm and tonal-pitch-space.
+- Summarized main data structures and algorithms.
+- Started update log to track future modifications.

--- a/packages/cognitive-theory-of-music/gttm/README.md
+++ b/packages/cognitive-theory-of-music/gttm/README.md
@@ -1,0 +1,13 @@
+# GTTM Module
+
+This package contains utilities for the *Generative Theory of Tonal Music* (GTTM).
+
+### Main Components
+- **src/analysis-result**: Data structures representing GTTM analyses, such as `GroupingStructure`, `MetricalStructure`, `TimeSpanReduction`, and `ProlongationalReduction`.
+- **src/sample**: Example data used for testing and demonstration.
+
+### Key Data Structures
+- `ReductionElement`: Abstract tree element used by reductions. Provides traversal helpers and depth calculations.
+- `TimeSpan` and `ProlongationalReduction`: Represent hierarchical reductions of a piece, capturing rhythm and harmonic functions.
+
+These structures enable the representation and processing of GTTM analysis results within the server.

--- a/packages/cognitive-theory-of-music/irm/README.md
+++ b/packages/cognitive-theory-of-music/irm/README.md
@@ -1,0 +1,13 @@
+# IRM Module
+
+Functions for *Implication-Realization Model* (IRM) analysis.
+
+### Main Components
+- **src/archetype**: Classes such as `Triad` representing melodic archetypes.
+- **src/colors**: Helpers for visualizing IRM results. For example `get_color_on_registral_scale` maps a `Triad` symbol to an RGB color.
+
+### Key Data Structures
+- `Triad`: Holds three consecutive notes and determines their archetypal symbol, registral motion, and intervallic motion.
+- `Monad`/`Dyad`: Simpler archetypes used to build larger structures.
+
+These elements allow evaluation and visualization of melodic expectation using Narmour's theory.

--- a/packages/cognitive-theory-of-music/tonal-pitch-space/README.md
+++ b/packages/cognitive-theory-of-music/tonal-pitch-space/README.md
@@ -1,0 +1,12 @@
+# Tonal-Pitch-Space Module
+
+Implements algorithms from Lerdahl's Tonal Pitch Space theory.
+
+### Main Components
+- **src/get-distance.ts**: Computes tonal distance between two chords using region, tonic, and basic-space distances.
+- **src/get-keys-include-the-chord.ts**: Lists keys that contain a given chord.
+
+### Key Data Structures
+- Functions operate on `RomanChord` and `Chord` representations from `@music-analyzer` packages.
+
+These utilities help evaluate tonal proximity and possible key contexts for chords.


### PR DESCRIPTION
## Summary
- document cognitive theory modules with new READMEs
- start update log and work log in `docs`

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843aa054bb083329104e072a1f13a8c